### PR TITLE
Upgrade to PHPUnit 9.4, modernize tests, apply php-cs-fixer, refactor, ...

### DIFF
--- a/Controller/ChangePasswordController.php
+++ b/Controller/ChangePasswordController.php
@@ -41,10 +41,6 @@ class ChangePasswordController extends AbstractController
 
     /**
      * ChangePasswordController constructor.
-     *
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param FactoryInterface         $formFactory
-     * @param UserManagerInterface     $userManager
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, UserManagerInterface $userManager)
     {
@@ -56,8 +52,6 @@ class ChangePasswordController extends AbstractController
     /**
      * Change user password.
      *
-     * @param Request $request
-     *
      * @return Response
      */
     public function changePasswordAction(Request $request)
@@ -68,7 +62,7 @@ class ChangePasswordController extends AbstractController
         }
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event,FOSUserEvents::CHANGE_PASSWORD_INITIALIZE);
+        $this->eventDispatcher->dispatch($event, FOSUserEvents::CHANGE_PASSWORD_INITIALIZE);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -81,7 +75,7 @@ class ChangePasswordController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event,FOSUserEvents::CHANGE_PASSWORD_SUCCESS);
+            $this->eventDispatcher->dispatch($event, FOSUserEvents::CHANGE_PASSWORD_SUCCESS);
 
             $this->userManager->updateUser($user);
 
@@ -90,7 +84,7 @@ class ChangePasswordController extends AbstractController
                 $response = new RedirectResponse($url);
             }
 
-            $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response),FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
+            $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response), FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
 
             return $response;
         }

--- a/Controller/GroupController.php
+++ b/Controller/GroupController.php
@@ -42,10 +42,6 @@ class GroupController extends AbstractController
 
     /**
      * GroupController constructor.
-     *
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param FactoryInterface         $formFactory
-     * @param GroupManagerInterface    $groupManager
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, GroupManagerInterface $groupManager)
     {
@@ -81,8 +77,7 @@ class GroupController extends AbstractController
     /**
      * Edit one group, show the edit form.
      *
-     * @param Request $request
-     * @param string  $groupName
+     * @param string $groupName
      *
      * @return Response
      */
@@ -91,7 +86,7 @@ class GroupController extends AbstractController
         $group = $this->findGroupBy('name', $groupName);
 
         $event = new GetResponseGroupEvent($group, $request);
-        $this->eventDispatcher->dispatch($event,FOSUserEvents::GROUP_EDIT_INITIALIZE);
+        $this->eventDispatcher->dispatch($event, FOSUserEvents::GROUP_EDIT_INITIALIZE);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -104,7 +99,7 @@ class GroupController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event,FOSUserEvents::GROUP_EDIT_SUCCESS);
+            $this->eventDispatcher->dispatch($event, FOSUserEvents::GROUP_EDIT_SUCCESS);
 
             $this->groupManager->updateGroup($group);
 
@@ -113,7 +108,7 @@ class GroupController extends AbstractController
                 $response = new RedirectResponse($url);
             }
 
-            $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response),FOSUserEvents::GROUP_EDIT_COMPLETED);
+            $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response), FOSUserEvents::GROUP_EDIT_COMPLETED);
 
             return $response;
         }
@@ -127,15 +122,13 @@ class GroupController extends AbstractController
     /**
      * Show the new form.
      *
-     * @param Request $request
-     *
      * @return Response
      */
     public function newAction(Request $request)
     {
         $group = $this->groupManager->createGroup('');
 
-        $this->eventDispatcher->dispatch(new GroupEvent($group, $request),FOSUserEvents::GROUP_CREATE_INITIALIZE);
+        $this->eventDispatcher->dispatch(new GroupEvent($group, $request), FOSUserEvents::GROUP_CREATE_INITIALIZE);
 
         $form = $this->formFactory->createForm();
         $form->setData($group);
@@ -144,7 +137,7 @@ class GroupController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event,FOSUserEvents::GROUP_CREATE_SUCCESS);
+            $this->eventDispatcher->dispatch($event, FOSUserEvents::GROUP_CREATE_SUCCESS);
 
             $this->groupManager->updateGroup($group);
 
@@ -153,7 +146,7 @@ class GroupController extends AbstractController
                 $response = new RedirectResponse($url);
             }
 
-            $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response),FOSUserEvents::GROUP_CREATE_COMPLETED);
+            $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response), FOSUserEvents::GROUP_CREATE_COMPLETED);
 
             return $response;
         }
@@ -166,8 +159,7 @@ class GroupController extends AbstractController
     /**
      * Delete one group.
      *
-     * @param Request $request
-     * @param string  $groupName
+     * @param string $groupName
      *
      * @return RedirectResponse
      */
@@ -178,7 +170,7 @@ class GroupController extends AbstractController
 
         $response = new RedirectResponse($this->generateUrl('fos_user_group_list'));
 
-        $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response),FOSUserEvents::GROUP_DELETE_COMPLETED);
+        $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response), FOSUserEvents::GROUP_DELETE_COMPLETED);
 
         return $response;
     }

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -40,10 +40,6 @@ class ProfileController extends AbstractController
 
     /**
      * ProfileController constructor.
-     *
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param FactoryInterface         $formFactory
-     * @param UserManagerInterface     $userManager
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, UserManagerInterface $userManager)
     {
@@ -69,8 +65,6 @@ class ProfileController extends AbstractController
 
     /**
      * Edit the user.
-     *
-     * @param Request $request
      *
      * @return Response
      */
@@ -104,7 +98,7 @@ class ProfileController extends AbstractController
                 $response = new RedirectResponse($url);
             }
 
-            $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response),FOSUserEvents::PROFILE_EDIT_COMPLETED);
+            $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response), FOSUserEvents::PROFILE_EDIT_COMPLETED);
 
             return $response;
         }

--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -44,11 +44,6 @@ class RegistrationController extends AbstractController
 
     /**
      * RegistrationController constructor.
-     *
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param FactoryInterface         $formFactory
-     * @param UserManagerInterface     $userManager
-     * @param TokenStorageInterface    $tokenStorage
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, UserManagerInterface $userManager, TokenStorageInterface $tokenStorage)
     {
@@ -59,8 +54,6 @@ class RegistrationController extends AbstractController
     }
 
     /**
-     * @param Request $request
-     *
      * @return Response
      */
     public function registerAction(Request $request)
@@ -69,7 +62,7 @@ class RegistrationController extends AbstractController
         $user->setEnabled(true);
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event,FOSUserEvents::REGISTRATION_INITIALIZE);
+        $this->eventDispatcher->dispatch($event, FOSUserEvents::REGISTRATION_INITIALIZE);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -83,7 +76,7 @@ class RegistrationController extends AbstractController
         if ($form->isSubmitted()) {
             if ($form->isValid()) {
                 $event = new FormEvent($form, $request);
-                $this->eventDispatcher->dispatch($event,FOSUserEvents::REGISTRATION_SUCCESS);
+                $this->eventDispatcher->dispatch($event, FOSUserEvents::REGISTRATION_SUCCESS);
 
                 $this->userManager->updateUser($user);
 
@@ -98,7 +91,7 @@ class RegistrationController extends AbstractController
             }
 
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event,FOSUserEvents::REGISTRATION_FAILURE);
+            $this->eventDispatcher->dispatch($event, FOSUserEvents::REGISTRATION_FAILURE);
 
             if (null !== $response = $event->getResponse()) {
                 return $response;
@@ -112,8 +105,6 @@ class RegistrationController extends AbstractController
 
     /**
      * Tell the user to check their email provider.
-     *
-     * @param Request $request
      *
      * @return RedirectResponse|Response
      */
@@ -140,8 +131,7 @@ class RegistrationController extends AbstractController
     /**
      * Receive the confirmation token from user email provider, login the user.
      *
-     * @param Request $request
-     * @param string  $token
+     * @param string $token
      *
      * @return Response
      */
@@ -159,7 +149,7 @@ class RegistrationController extends AbstractController
         $user->setEnabled(true);
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event,FOSUserEvents::REGISTRATION_CONFIRM);
+        $this->eventDispatcher->dispatch($event, FOSUserEvents::REGISTRATION_CONFIRM);
 
         $userManager->updateUser($user);
 
@@ -168,15 +158,13 @@ class RegistrationController extends AbstractController
             $response = new RedirectResponse($url);
         }
 
-        $this->eventDispatcher->dispatch( new FilterUserResponseEvent($user, $request, $response),FOSUserEvents::REGISTRATION_CONFIRMED);
+        $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response), FOSUserEvents::REGISTRATION_CONFIRMED);
 
         return $response;
     }
 
     /**
      * Tell the user his account is now confirmed.
-     *
-     * @param Request $request
      *
      * @return Response
      */
@@ -194,8 +182,6 @@ class RegistrationController extends AbstractController
     }
 
     /**
-     * @param SessionInterface $session
-     *
      * @return string|null
      */
     private function getTargetUrlFromSession(SessionInterface $session)

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -48,12 +48,7 @@ class ResettingController extends AbstractController
     private $retryTtl;
 
     /**
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param FactoryInterface         $formFactory
-     * @param UserManagerInterface     $userManager
-     * @param TokenGeneratorInterface  $tokenGenerator
-     * @param MailerInterface          $mailer
-     * @param int                      $retryTtl
+     * @param int $retryTtl
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, UserManagerInterface $userManager, TokenGeneratorInterface $tokenGenerator, MailerInterface $mailer, $retryTtl)
     {
@@ -76,8 +71,6 @@ class ResettingController extends AbstractController
     /**
      * Request reset user password: submit form and send email.
      *
-     * @param Request $request
-     *
      * @return Response
      */
     public function sendEmailAction(Request $request)
@@ -87,7 +80,7 @@ class ResettingController extends AbstractController
         $user = $this->userManager->findUserByUsernameOrEmail($username);
 
         $event = new GetResponseNullableUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event,FOSUserEvents::RESETTING_SEND_EMAIL_INITIALIZE);
+        $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_SEND_EMAIL_INITIALIZE);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -95,7 +88,7 @@ class ResettingController extends AbstractController
 
         if (null !== $user && !$user->isPasswordRequestNonExpired($this->retryTtl)) {
             $event = new GetResponseUserEvent($user, $request);
-            $this->eventDispatcher->dispatch($event,FOSUserEvents::RESETTING_RESET_REQUEST);
+            $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_RESET_REQUEST);
 
             if (null !== $event->getResponse()) {
                 return $event->getResponse();
@@ -106,7 +99,7 @@ class ResettingController extends AbstractController
             }
 
             $event = new GetResponseUserEvent($user, $request);
-            $this->eventDispatcher->dispatch($event,FOSUserEvents::RESETTING_SEND_EMAIL_CONFIRM);
+            $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_SEND_EMAIL_CONFIRM);
 
             if (null !== $event->getResponse()) {
                 return $event->getResponse();
@@ -117,7 +110,7 @@ class ResettingController extends AbstractController
             $this->userManager->updateUser($user);
 
             $event = new GetResponseUserEvent($user, $request);
-            $this->eventDispatcher->dispatch($event,FOSUserEvents::RESETTING_SEND_EMAIL_COMPLETED);
+            $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_SEND_EMAIL_COMPLETED);
 
             if (null !== $event->getResponse()) {
                 return $event->getResponse();
@@ -129,8 +122,6 @@ class ResettingController extends AbstractController
 
     /**
      * Tell the user to check his email provider.
-     *
-     * @param Request $request
      *
      * @return Response
      */
@@ -151,8 +142,7 @@ class ResettingController extends AbstractController
     /**
      * Reset user password.
      *
-     * @param Request $request
-     * @param string  $token
+     * @param string $token
      *
      * @return Response
      */
@@ -165,7 +155,7 @@ class ResettingController extends AbstractController
         }
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event,FOSUserEvents::RESETTING_RESET_INITIALIZE);
+        $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_RESET_INITIALIZE);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -178,7 +168,7 @@ class ResettingController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event,FOSUserEvents::RESETTING_RESET_SUCCESS);
+            $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_RESET_SUCCESS);
 
             $this->userManager->updateUser($user);
 

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -33,8 +33,6 @@ class SecurityController extends AbstractController
 
     /**
      * SecurityController constructor.
-     *
-     * @param CsrfTokenManagerInterface|null $tokenManager
      */
     public function __construct(CsrfTokenManagerInterface $tokenManager = null)
     {
@@ -42,8 +40,6 @@ class SecurityController extends AbstractController
     }
 
     /**
-     * @param Request $request
-     *
      * @return Response
      */
     public function loginAction(Request $request)
@@ -95,8 +91,6 @@ class SecurityController extends AbstractController
     /**
      * Renders the login template with the given parameters. Overwrite this function in
      * an extended controller to provide additional data for the login template.
-     *
-     * @param array $data
      *
      * @return Response
      */

--- a/DependencyInjection/FOSUserExtension.php
+++ b/DependencyInjection/FOSUserExtension.php
@@ -130,7 +130,7 @@ class FOSUserExtension extends Extension
         }
 
         if ($this->mailerNeeded) {
-            if ($config['service']['mailer'] !== 'fos_user.mailer.default' ) {
+            if ('fos_user.mailer.default' !== $config['service']['mailer']) {
                 $container->setAlias('fos_user.templating', $config['service']['templating']);
             }
             $container->setAlias('fos_user.mailer', $config['service']['mailer']);

--- a/Doctrine/GroupManager.php
+++ b/Doctrine/GroupManager.php
@@ -11,34 +11,18 @@
 
 namespace FOS\UserBundle\Doctrine;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
 use FOS\UserBundle\Model\GroupInterface;
 use FOS\UserBundle\Model\GroupManager as BaseGroupManager;
 
 class GroupManager extends BaseGroupManager
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    protected $objectManager;
+    protected ObjectManager $objectManager;
+    protected string$class;
+    protected ObjectRepository $repository;
 
-    /**
-     * @var string
-     */
-    protected $class;
-
-    /**
-     * @var ObjectRepository
-     */
-    protected $repository;
-
-    /**
-     * GroupManager constructor.
-     *
-     * @param string $class
-     */
-    public function __construct(EntityManagerInterface $om, $class)
+    public function __construct(ObjectManager $om, string $class)
     {
         $this->objectManager = $om;
         $this->repository = $om->getRepository($class);
@@ -50,7 +34,7 @@ class GroupManager extends BaseGroupManager
     /**
      * {@inheritdoc}
      */
-    public function deleteGroup(GroupInterface $group)
+    public function deleteGroup(GroupInterface $group): void
     {
         $this->objectManager->remove($group);
         $this->objectManager->flush();
@@ -59,7 +43,7 @@ class GroupManager extends BaseGroupManager
     /**
      * {@inheritdoc}
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -83,7 +67,7 @@ class GroupManager extends BaseGroupManager
     /**
      * {@inheritdoc}
      */
-    public function updateGroup(GroupInterface $group, $andFlush = true)
+    public function updateGroup(GroupInterface $group, $andFlush = true): void
     {
         $this->objectManager->persist($group);
         if ($andFlush) {

--- a/Doctrine/UserManager.php
+++ b/Doctrine/UserManager.php
@@ -11,7 +11,7 @@
 
 namespace FOS\UserBundle\Doctrine;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManager as BaseUserManager;
@@ -20,22 +20,10 @@ use FOS\UserBundle\Util\PasswordUpdaterInterface;
 
 class UserManager extends BaseUserManager
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    protected $objectManager;
+    protected ObjectManager $objectManager;
+    private string $class;
 
-    /**
-     * @var string
-     */
-    private $class;
-
-    /**
-     * Constructor.
-     *
-     * @param string $class
-     */
-    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater, EntityManagerInterface $om, $class)
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater, ObjectManager $om, string $class)
     {
         parent::__construct($passwordUpdater, $canonicalFieldsUpdater);
 
@@ -55,7 +43,7 @@ class UserManager extends BaseUserManager
     /**
      * {@inheritdoc}
      */
-    public function getClass()
+    public function getClass(): string
     {
         if (false !== strpos($this->class, ':')) {
             $metadata = $this->objectManager->getClassMetadata($this->class);
@@ -103,10 +91,7 @@ class UserManager extends BaseUserManager
         }
     }
 
-    /**
-     * @return ObjectRepository
-     */
-    protected function getRepository()
+    protected function getRepository(): ObjectRepository
     {
         return $this->objectManager->getRepository($this->getClass());
     }

--- a/Event/FormEvent.php
+++ b/Event/FormEvent.php
@@ -11,10 +11,10 @@
 
 namespace FOS\UserBundle\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class FormEvent extends Event
 {

--- a/Event/GroupEvent.php
+++ b/Event/GroupEvent.php
@@ -12,8 +12,8 @@
 namespace FOS\UserBundle\Event;
 
 use FOS\UserBundle\Model\GroupInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class GroupEvent extends Event
 {

--- a/Event/UserEvent.php
+++ b/Event/UserEvent.php
@@ -12,8 +12,8 @@
 namespace FOS\UserBundle\Event;
 
 use FOS\UserBundle\Model\UserInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class UserEvent extends Event
 {

--- a/EventListener/AuthenticationListener.php
+++ b/EventListener/AuthenticationListener.php
@@ -62,7 +62,7 @@ class AuthenticationListener implements EventSubscriberInterface
         try {
             $this->loginManager->logInUser($this->firewallName, $event->getUser(), $event->getResponse());
 
-            $eventDispatcher->dispatch(new UserEvent($event->getUser(), $event->getRequest()),FOSUserEvents::SECURITY_IMPLICIT_LOGIN);
+            $eventDispatcher->dispatch(new UserEvent($event->getUser(), $event->getRequest()), FOSUserEvents::SECURITY_IMPLICIT_LOGIN);
         } catch (AccountStatusException $ex) {
             // We simply do not authenticate users which do not pass the user
             // checker (not enabled, expired, etc.).

--- a/EventListener/FlashListener.php
+++ b/EventListener/FlashListener.php
@@ -12,9 +12,9 @@
 namespace FOS\UserBundle\EventListener;
 
 use FOS\UserBundle\FOSUserEvents;
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FlashListener implements EventSubscriberInterface

--- a/Mailer/AbstractMailer.php
+++ b/Mailer/AbstractMailer.php
@@ -14,9 +14,8 @@ namespace FOS\UserBundle\Mailer;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
- * Class AbstractMailer
+ * Class AbstractMailer.
  *
- * @package FOS\UserBundle\Mailer
  * @author Nikolay Nikolaev <evrinoma@gmail.com>
  */
 abstract class AbstractMailer implements MailerInterface
@@ -49,8 +48,8 @@ abstract class AbstractMailer implements MailerInterface
     /**
      * @param array|string $fromEmail
      * @param array|string $toEmail
-     * @param string $template
-     * @param array  $context
+     * @param string       $template
+     * @param array        $context
      */
     abstract protected function sendMessage($fromEmail, $toEmail, $template, $context = []);
 }

--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -31,7 +31,7 @@ class Mailer extends AbstractMailer
     {
         $this->template = $template;
 
-        parent::__construct($mailer,$router,$parameters);
+        parent::__construct($mailer, $router, $parameters);
     }
 
     /**
@@ -45,7 +45,7 @@ class Mailer extends AbstractMailer
             'user' => $user,
             'confirmationUrl' => $url,
         ]);
-        $this->sendMessage($this->parameters['from_email']['confirmation'], (string) $user->getEmail(),$rendered);
+        $this->sendMessage($this->parameters['from_email']['confirmation'], (string) $user->getEmail(), $rendered);
     }
 
     /**
@@ -59,12 +59,11 @@ class Mailer extends AbstractMailer
             'user' => $user,
             'confirmationUrl' => $url,
         ]);
-        $this->sendMessage($this->parameters['from_email']['resetting'], (string) $user->getEmail(),$rendered);
+        $this->sendMessage($this->parameters['from_email']['resetting'], (string) $user->getEmail(), $rendered);
     }
 
-
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function sendMessage($fromEmail, $toEmail, $template, $context = [])
     {

--- a/Mailer/TemplateInterface.php
+++ b/Mailer/TemplateInterface.php
@@ -9,13 +9,10 @@
  * file that was distributed with this source code.
  */
 
-
 namespace FOS\UserBundle\Mailer;
 
 /**
- * Interface TemplateInterface
- *
- * @package FOS\UserBundle\Mailer
+ * Interface TemplateInterface.
  */
 interface TemplateInterface
 {
@@ -23,9 +20,6 @@ interface TemplateInterface
      * Renders a template.
      *
      * @param string $name The template name
-     * @param array  $context
-     *
-     * @return string
      */
     public function render($name, array $context = []): string;
 }

--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -32,7 +32,7 @@ class TwigSwiftMailer extends AbstractMailer
     {
         $this->twig = $twig;
 
-        parent::__construct($mailer,$router,$parameters);
+        parent::__construct($mailer, $router, $parameters);
     }
 
     /**
@@ -48,7 +48,7 @@ class TwigSwiftMailer extends AbstractMailer
             'confirmationUrl' => $url,
         ];
 
-        $this->sendMessage($this->parameters['from_email']['confirmation'], (string) $user->getEmail(),$template, $context);
+        $this->sendMessage($this->parameters['from_email']['confirmation'], (string) $user->getEmail(), $template, $context);
     }
 
     /**
@@ -64,11 +64,11 @@ class TwigSwiftMailer extends AbstractMailer
             'confirmationUrl' => $url,
         ];
 
-        $this->sendMessage($this->parameters['from_email']['resetting'], (string) $user->getEmail(),$template, $context);
+        $this->sendMessage($this->parameters['from_email']['resetting'], (string) $user->getEmail(), $template, $context);
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function sendMessage($fromEmail, $toEmail, $template, $context = [])
     {

--- a/Tests/Command/ActivateUserCommandTest.php
+++ b/Tests/Command/ActivateUserCommandTest.php
@@ -15,11 +15,12 @@ use FOS\UserBundle\Command\ActivateUserCommand;
 use FOS\UserBundle\Util\UserManipulator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ActivateUserCommandTest extends TestCase
 {
-    public function testExecute()
+    public function testExecute(): void
     {
         $commandTester = $this->createCommandTester($this->getManipulator('user'));
         $exitCode = $commandTester->execute([
@@ -29,21 +30,22 @@ class ActivateUserCommandTest extends TestCase
             'interactive' => false,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/User "user" has been activated/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/User "user" has been activated/', $commandTester->getDisplay());
     }
 
-    public function testExecuteInteractiveWithQuestionHelper()
+    public function testExecuteInteractiveWithQuestionHelper(): void
     {
         $application = new Application();
 
-        $helper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+        $helper = $this->getMockBuilder(QuestionHelper::class)
             ->setMethods(['ask'])
             ->getMock();
 
-        $helper->expects($this->at(0))
+        $helper
+            ->expects(self::at(0))
             ->method('ask')
-            ->will($this->returnValue('user'));
+            ->willReturn('user');
 
         $application->getHelperSet()->set($helper, 'question');
 
@@ -53,14 +55,11 @@ class ActivateUserCommandTest extends TestCase
             'interactive' => true,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/User "user" has been activated/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/User "user" has been activated/', $commandTester->getDisplay());
     }
 
-    /**
-     * @return CommandTester
-     */
-    private function createCommandTester(UserManipulator $manipulator, Application $application = null)
+    private function createCommandTester(UserManipulator $manipulator, Application $application = null): CommandTester
     {
         if (null === $application) {
             $application = new Application();
@@ -82,12 +81,12 @@ class ActivateUserCommandTest extends TestCase
      */
     private function getManipulator($username)
     {
-        $manipulator = $this->getMockBuilder('FOS\UserBundle\Util\UserManipulator')
+        $manipulator = $this->getMockBuilder(UserManipulator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $manipulator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('activate')
             ->with($username)
         ;

--- a/Tests/Command/ChangePasswordCommandTest.php
+++ b/Tests/Command/ChangePasswordCommandTest.php
@@ -15,11 +15,12 @@ use FOS\UserBundle\Command\ChangePasswordCommand;
 use FOS\UserBundle\Util\UserManipulator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ChangePasswordCommandTest extends TestCase
 {
-    public function testExecute()
+    public function testExecute(): void
     {
         $commandTester = $this->createCommandTester($this->getManipulator('user', 'pass'));
         $exitCode = $commandTester->execute([
@@ -30,24 +31,24 @@ class ChangePasswordCommandTest extends TestCase
             'interactive' => false,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/Changed password for user user/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/Changed password for user user/', $commandTester->getDisplay());
     }
 
-    public function testExecuteInteractiveWithQuestionHelper()
+    public function testExecuteInteractiveWithQuestionHelper(): void
     {
         $application = new Application();
 
-        $helper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+        $helper = $this->getMockBuilder(QuestionHelper::class)
             ->setMethods(['ask'])
             ->getMock();
 
-        $helper->expects($this->at(0))
+        $helper->expects(self::at(0))
             ->method('ask')
-            ->will($this->returnValue('user'));
-        $helper->expects($this->at(1))
+            ->willReturn('user');
+        $helper->expects(self::at(1))
             ->method('ask')
-            ->will($this->returnValue('pass'));
+            ->willReturn('pass');
 
         $application->getHelperSet()->set($helper, 'question');
 
@@ -57,16 +58,11 @@ class ChangePasswordCommandTest extends TestCase
             'interactive' => true,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/Changed password for user user/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/Changed password for user user/', $commandTester->getDisplay());
     }
 
-    /**
-     * @param UserManipulator $container
-     *
-     * @return CommandTester
-     */
-    private function createCommandTester(UserManipulator $userManipulator, Application $application = null)
+    private function createCommandTester(UserManipulator $userManipulator, Application $application = null): CommandTester
     {
         if (null === $application) {
             $application = new Application();
@@ -89,12 +85,12 @@ class ChangePasswordCommandTest extends TestCase
      */
     private function getManipulator($username, $password)
     {
-        $manipulator = $this->getMockBuilder('FOS\UserBundle\Util\UserManipulator')
+        $manipulator = $this->getMockBuilder(UserManipulator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $manipulator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('changePassword')
             ->with($username, $password)
         ;

--- a/Tests/Command/CreateUserCommandTest.php
+++ b/Tests/Command/CreateUserCommandTest.php
@@ -15,11 +15,12 @@ use FOS\UserBundle\Command\CreateUserCommand;
 use FOS\UserBundle\Util\UserManipulator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class CreateUserCommandTest extends TestCase
 {
-    public function testExecute()
+    public function testExecute(): void
     {
         $commandTester = $this->createCommandTester($this->getManipulator('user', 'pass', 'email', true, false));
         $exitCode = $commandTester->execute([
@@ -31,29 +32,29 @@ class CreateUserCommandTest extends TestCase
             'interactive' => false,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/Created user user/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/Created user user/', $commandTester->getDisplay());
     }
 
-    public function testExecuteInteractiveWithQuestionHelper()
+    public function testExecuteInteractiveWithQuestionHelper(): void
     {
         $application = new Application();
 
-        $helper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+        $helper = $this->getMockBuilder(QuestionHelper::class)
             ->setMethods(['ask'])
             ->getMock();
 
-        $helper->expects($this->at(0))
+        $helper->expects(self::at(0))
             ->method('ask')
-            ->will($this->returnValue('user'));
+            ->willReturn('user');
 
-        $helper->expects($this->at(1))
+        $helper->expects(self::at(1))
             ->method('ask')
-            ->will($this->returnValue('email'));
+            ->willReturn('email');
 
-        $helper->expects($this->at(2))
+        $helper->expects(self::at(2))
             ->method('ask')
-            ->will($this->returnValue('pass'));
+            ->willReturn('pass');
 
         $application->getHelperSet()->set($helper, 'question');
 
@@ -65,14 +66,11 @@ class CreateUserCommandTest extends TestCase
             'interactive' => true,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/Created user user/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/Created user user/', $commandTester->getDisplay());
     }
 
-    /**
-     * @return CommandTester
-     */
-    private function createCommandTester(UserManipulator $manipulator, Application $application = null)
+    private function createCommandTester(UserManipulator $manipulator, Application $application = null): CommandTester
     {
         if (null === $application) {
             $application = new Application();
@@ -98,12 +96,12 @@ class CreateUserCommandTest extends TestCase
      */
     private function getManipulator($username, $password, $email, $active, $superadmin)
     {
-        $manipulator = $this->getMockBuilder('FOS\UserBundle\Util\UserManipulator')
+        $manipulator = $this->getMockBuilder(UserManipulator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $manipulator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('create')
             ->with($username, $password, $email, $active, $superadmin)
         ;

--- a/Tests/Command/DeactivateUserCommandTest.php
+++ b/Tests/Command/DeactivateUserCommandTest.php
@@ -15,11 +15,12 @@ use FOS\UserBundle\Command\DeactivateUserCommand;
 use FOS\UserBundle\Util\UserManipulator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class DeactivateUserCommandTest extends TestCase
 {
-    public function testExecute()
+    public function testExecute(): void
     {
         $commandTester = $this->createCommandTester($this->getManipulator('user'));
         $exitCode = $commandTester->execute([
@@ -29,21 +30,22 @@ class DeactivateUserCommandTest extends TestCase
             'interactive' => false,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/User "user" has been deactivated/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/User "user" has been deactivated/', $commandTester->getDisplay());
     }
 
-    public function testExecuteInteractiveWithQuestionHelper()
+    public function testExecuteInteractiveWithQuestionHelper(): void
     {
         $application = new Application();
 
-        $helper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+        $helper = $this->getMockBuilder(QuestionHelper::class)
             ->setMethods(['ask'])
             ->getMock();
 
-        $helper->expects($this->at(0))
+        $helper
+            ->expects(self::at(0))
             ->method('ask')
-            ->will($this->returnValue('user'));
+            ->willReturn('user');
 
         $application->getHelperSet()->set($helper, 'question');
 
@@ -53,14 +55,11 @@ class DeactivateUserCommandTest extends TestCase
             'interactive' => true,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/User "user" has been deactivated/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/User "user" has been deactivated/', $commandTester->getDisplay());
     }
 
-    /**
-     * @return CommandTester
-     */
-    private function createCommandTester(UserManipulator $manipulator, Application $application = null)
+    private function createCommandTester(UserManipulator $manipulator, Application $application = null): CommandTester
     {
         if (null === $application) {
             $application = new Application();
@@ -82,12 +81,12 @@ class DeactivateUserCommandTest extends TestCase
      */
     private function getManipulator($username)
     {
-        $manipulator = $this->getMockBuilder('FOS\UserBundle\Util\UserManipulator')
+        $manipulator = $this->getMockBuilder(UserManipulator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $manipulator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deactivate')
             ->with($username)
         ;

--- a/Tests/Command/DemoteUserCommandTest.php
+++ b/Tests/Command/DemoteUserCommandTest.php
@@ -15,11 +15,12 @@ use FOS\UserBundle\Command\DemoteUserCommand;
 use FOS\UserBundle\Util\UserManipulator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class DemoteUserCommandTest extends TestCase
 {
-    public function testExecute()
+    public function testExecute(): void
     {
         $commandTester = $this->createCommandTester($this->getManipulator('user', 'role', false));
         $exitCode = $commandTester->execute([
@@ -30,24 +31,24 @@ class DemoteUserCommandTest extends TestCase
             'interactive' => false,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/Role "role" has been removed from user "user"/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/Role "role" has been removed from user "user"/', $commandTester->getDisplay());
     }
 
-    public function testExecuteInteractiveWithQuestionHelper()
+    public function testExecuteInteractiveWithQuestionHelper(): void
     {
         $application = new Application();
 
-        $helper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+        $helper = $this->getMockBuilder(QuestionHelper::class)
             ->setMethods(['ask'])
             ->getMock();
 
-        $helper->expects($this->at(0))
+        $helper->expects(self::at(0))
             ->method('ask')
-            ->will($this->returnValue('user'));
-        $helper->expects($this->at(1))
+            ->willReturn('user');
+        $helper->expects(self::at(1))
             ->method('ask')
-            ->will($this->returnValue('role'));
+            ->willReturn('role');
 
         $application->getHelperSet()->set($helper, 'question');
 
@@ -57,14 +58,11 @@ class DemoteUserCommandTest extends TestCase
             'interactive' => true,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/Role "role" has been removed from user "user"/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/Role "role" has been removed from user "user"/', $commandTester->getDisplay());
     }
 
-    /**
-     * @return CommandTester
-     */
-    private function createCommandTester(UserManipulator $manipulator, Application $application = null)
+    private function createCommandTester(UserManipulator $manipulator, Application $application = null): CommandTester
     {
         if (null === $application) {
             $application = new Application();
@@ -88,23 +86,23 @@ class DemoteUserCommandTest extends TestCase
      */
     private function getManipulator($username, $role, $super)
     {
-        $manipulator = $this->getMockBuilder('FOS\UserBundle\Util\UserManipulator')
+        $manipulator = $this->getMockBuilder(UserManipulator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         if ($super) {
             $manipulator
-                ->expects($this->once())
+                ->expects(self::once())
                 ->method('demote')
                 ->with($username)
-                ->will($this->returnValue(true))
+                ->willReturn(true)
             ;
         } else {
             $manipulator
-                ->expects($this->once())
+                ->expects(self::once())
                 ->method('removeRole')
                 ->with($username, $role)
-                ->will($this->returnValue(true))
+                ->willReturn(true)
             ;
         }
 

--- a/Tests/Command/PromoteUserCommandTest.php
+++ b/Tests/Command/PromoteUserCommandTest.php
@@ -15,11 +15,12 @@ use FOS\UserBundle\Command\PromoteUserCommand;
 use FOS\UserBundle\Util\UserManipulator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class PromoteUserCommandTest extends TestCase
 {
-    public function testExecute()
+    public function testExecute(): void
     {
         $commandTester = $this->createCommandTester($this->getManipulator('user', 'role', false));
         $exitCode = $commandTester->execute([
@@ -30,24 +31,24 @@ class PromoteUserCommandTest extends TestCase
             'interactive' => false,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/Role "role" has been added to user "user"/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/Role "role" has been added to user "user"/', $commandTester->getDisplay());
     }
 
-    public function testExecuteInteractiveWithQuestionHelper()
+    public function testExecuteInteractiveWithQuestionHelper(): void
     {
         $application = new Application();
 
-        $helper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+        $helper = $this->getMockBuilder(QuestionHelper::class)
             ->setMethods(['ask'])
             ->getMock();
 
-        $helper->expects($this->at(0))
+        $helper->expects(self::at(0))
             ->method('ask')
-            ->will($this->returnValue('user'));
-        $helper->expects($this->at(1))
+            ->willReturn('user');
+        $helper->expects(self::at(1))
             ->method('ask')
-            ->will($this->returnValue('role'));
+            ->willReturn('role');
 
         $application->getHelperSet()->set($helper, 'question');
 
@@ -57,14 +58,11 @@ class PromoteUserCommandTest extends TestCase
             'interactive' => true,
         ]);
 
-        $this->assertSame(0, $exitCode, 'Returns 0 in case of success');
-        $this->assertRegExp('/Role "role" has been added to user "user"/', $commandTester->getDisplay());
+        self::assertSame(0, $exitCode, 'Returns 0 in case of success');
+        self::assertMatchesRegularExpression('/Role "role" has been added to user "user"/', $commandTester->getDisplay());
     }
 
-    /**
-     * @return CommandTester
-     */
-    private function createCommandTester(UserManipulator $manipulator, Application $application = null)
+    private function createCommandTester(UserManipulator $manipulator, Application $application = null): CommandTester
     {
         if (null === $application) {
             $application = new Application();
@@ -88,23 +86,23 @@ class PromoteUserCommandTest extends TestCase
      */
     private function getManipulator($username, $role, $super)
     {
-        $manipulator = $this->getMockBuilder('FOS\UserBundle\Util\UserManipulator')
+        $manipulator = $this->getMockBuilder(UserManipulator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         if ($super) {
             $manipulator
-                ->expects($this->once())
+                ->expects(self::once())
                 ->method('promote')
                 ->with($username)
-                ->will($this->returnValue(true))
+                ->willReturn(true)
             ;
         } else {
             $manipulator
-                ->expects($this->once())
+                ->expects(self::once())
                 ->method('addRole')
                 ->with($username, $role)
-                ->will($this->returnValue(true))
+                ->willReturn(true)
             ;
         }
 

--- a/Tests/DependencyInjection/FOSUserExtensionTest.php
+++ b/Tests/DependencyInjection/FOSUserExtensionTest.php
@@ -13,86 +13,74 @@ namespace FOS\UserBundle\Tests\DependencyInjection;
 
 use FOS\UserBundle\DependencyInjection\FOSUserExtension;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Parser;
 
 class FOSUserExtensionTest extends TestCase
 {
-    /** @var ContainerBuilder */
-    protected $configuration;
+    protected ?ContainerBuilder $configuration;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->configuration = null;
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
-    public function testUserLoadThrowsExceptionUnlessDatabaseDriverSet()
+    public function testUserLoadThrowsExceptionUnlessDatabaseDriverSet(): void
     {
+        $this->expectException(InvalidConfigurationException::class);
         $loader = new FOSUserExtension();
         $config = $this->getEmptyConfig();
         unset($config['db_driver']);
         $loader->load([$config], new ContainerBuilder());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
-    public function testUserLoadThrowsExceptionUnlessDatabaseDriverIsValid()
+    public function testUserLoadThrowsExceptionUnlessDatabaseDriverIsValid(): void
     {
+        $this->expectException(InvalidConfigurationException::class);
         $loader = new FOSUserExtension();
         $config = $this->getEmptyConfig();
         $config['db_driver'] = 'foo';
         $loader->load([$config], new ContainerBuilder());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
-    public function testUserLoadThrowsExceptionUnlessFirewallNameSet()
+    public function testUserLoadThrowsExceptionUnlessFirewallNameSet(): void
     {
+        $this->expectException(InvalidConfigurationException::class);
         $loader = new FOSUserExtension();
         $config = $this->getEmptyConfig();
         unset($config['firewall_name']);
         $loader->load([$config], new ContainerBuilder());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
-    public function testUserLoadThrowsExceptionUnlessGroupModelClassSet()
+    public function testUserLoadThrowsExceptionUnlessGroupModelClassSet(): void
     {
+        $this->expectException(InvalidConfigurationException::class);
         $loader = new FOSUserExtension();
         $config = $this->getFullConfig();
         unset($config['group']['group_class']);
         $loader->load([$config], new ContainerBuilder());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
-    public function testUserLoadThrowsExceptionUnlessUserModelClassSet()
+    public function testUserLoadThrowsExceptionUnlessUserModelClassSet(): void
     {
+        $this->expectException(InvalidConfigurationException::class);
         $loader = new FOSUserExtension();
         $config = $this->getEmptyConfig();
         unset($config['user_class']);
         $loader->load([$config], new ContainerBuilder());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
-    public function testCustomDriverWithoutManager()
+    public function testCustomDriverWithoutManager(): void
     {
+        $this->expectException(InvalidConfigurationException::class);
         $loader = new FOSUserExtension();
         $config = $this->getEmptyConfig();
         $config['db_driver'] = 'custom';
         $loader->load([$config], new ContainerBuilder());
     }
 
-    public function testCustomDriver()
+    public function testCustomDriver(): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
@@ -106,7 +94,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertParameter('custom', 'fos_user.storage');
     }
 
-    public function testDisableRegistration()
+    public function testDisableRegistration(): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
@@ -119,7 +107,7 @@ class FOSUserExtensionTest extends TestCase
         $parameters = $this->configuration->getParameterBag()->resolveValue(
             $mailer->getArgument(2)
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'confirmation' => ['no-registration@acme.com' => 'Acme Ltd'],
                 'resetting' => ['admin@acme.org' => 'Acme Corp'],
@@ -128,7 +116,7 @@ class FOSUserExtensionTest extends TestCase
         );
     }
 
-    public function testDisableResetting()
+    public function testDisableResetting(): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
@@ -141,7 +129,7 @@ class FOSUserExtensionTest extends TestCase
         $parameters = $this->configuration->getParameterBag()->resolveValue(
             $mailer->getArgument(2)
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'confirmation' => ['admin@acme.org' => 'Acme Corp'],
                 'resetting' => ['no-resetting@acme.com' => 'Acme Ltd'],
@@ -150,7 +138,7 @@ class FOSUserExtensionTest extends TestCase
         );
     }
 
-    public function testDisableProfile()
+    public function testDisableProfile(): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
@@ -160,7 +148,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertNotHasDefinition('fos_user.profile.form.factory');
     }
 
-    public function testDisableChangePassword()
+    public function testDisableChangePassword(): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
@@ -173,7 +161,7 @@ class FOSUserExtensionTest extends TestCase
     /**
      * @dataProvider providerEmailsDisabledFeature
      */
-    public function testEmailsDisabledFeature($testConfig, $registration, $resetting)
+    public function testEmailsDisabledFeature($testConfig, $registration, $resetting): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
@@ -185,7 +173,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertParameter($resetting, 'fos_user.resetting.email.from_email');
     }
 
-    public function providerEmailsDisabledFeature()
+    public function providerEmailsDisabledFeature(): array
     {
         $configBothFeaturesDisabled = ['registration' => false, 'resetting' => false];
         $configResettingDisabled = ['resetting' => false];
@@ -217,21 +205,21 @@ class FOSUserExtensionTest extends TestCase
         ];
     }
 
-    public function testUserLoadModelClassWithDefaults()
+    public function testUserLoadModelClassWithDefaults(): void
     {
         $this->createEmptyConfiguration();
 
         $this->assertParameter('Acme\MyBundle\Document\User', 'fos_user.model.user.class');
     }
 
-    public function testUserLoadModelClass()
+    public function testUserLoadModelClass(): void
     {
         $this->createFullConfiguration();
 
         $this->assertParameter('Acme\MyBundle\Entity\User', 'fos_user.model.user.class');
     }
 
-    public function testUserLoadManagerClassWithDefaults()
+    public function testUserLoadManagerClassWithDefaults(): void
     {
         $this->createEmptyConfiguration();
 
@@ -241,7 +229,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertNotHasDefinition('fos_user.group_manager');
     }
 
-    public function testUserLoadManagerClass()
+    public function testUserLoadManagerClass(): void
     {
         $this->createFullConfiguration();
 
@@ -251,7 +239,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertAlias('fos_user.group_manager.default', 'fos_user.group_manager');
     }
 
-    public function testUserLoadFormClass()
+    public function testUserLoadFormClass(): void
     {
         $this->createFullConfiguration();
 
@@ -262,7 +250,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertParameter('acme_my_resetting', 'fos_user.resetting.form.type');
     }
 
-    public function testUserLoadFormNameWithDefaults()
+    public function testUserLoadFormNameWithDefaults(): void
     {
         $this->createEmptyConfiguration();
 
@@ -272,7 +260,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertParameter('fos_user_resetting_form', 'fos_user.resetting.form.name');
     }
 
-    public function testUserLoadFormName()
+    public function testUserLoadFormName(): void
     {
         $this->createFullConfiguration();
 
@@ -283,7 +271,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertParameter('acme_resetting_form', 'fos_user.resetting.form.name');
     }
 
-    public function testUserLoadFormServiceWithDefaults()
+    public function testUserLoadFormServiceWithDefaults(): void
     {
         $this->createEmptyConfiguration();
 
@@ -294,7 +282,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertHasDefinition('fos_user.resetting.form.factory');
     }
 
-    public function testUserLoadFormService()
+    public function testUserLoadFormService(): void
     {
         $this->createFullConfiguration();
 
@@ -305,7 +293,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertHasDefinition('fos_user.resetting.form.factory');
     }
 
-    public function testUserLoadConfirmationEmailWithDefaults()
+    public function testUserLoadConfirmationEmailWithDefaults(): void
     {
         $this->createEmptyConfiguration();
 
@@ -317,7 +305,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertParameter(86400, 'fos_user.resetting.token_ttl');
     }
 
-    public function testUserLoadConfirmationEmail()
+    public function testUserLoadConfirmationEmail(): void
     {
         $this->createFullConfiguration();
 
@@ -329,7 +317,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertParameter(7200, 'fos_user.resetting.retry_ttl');
     }
 
-    public function testUserLoadUtilServiceWithDefaults()
+    public function testUserLoadUtilServiceWithDefaults(): void
     {
         $this->createEmptyConfiguration();
 
@@ -338,7 +326,7 @@ class FOSUserExtensionTest extends TestCase
         $this->assertAlias('fos_user.util.canonicalizer.default', 'fos_user.util.username_canonicalizer');
     }
 
-    public function testUserLoadUtilService()
+    public function testUserLoadUtilService(): void
     {
         $this->createFullConfiguration();
 
@@ -348,14 +336,14 @@ class FOSUserExtensionTest extends TestCase
         $this->assertAlias('acme_my.username_canonicalizer', 'fos_user.util.username_canonicalizer');
     }
 
-    public function testUserLoadFlashesByDefault()
+    public function testUserLoadFlashesByDefault(): void
     {
         $this->createEmptyConfiguration();
 
         $this->assertHasDefinition('fos_user.listener.flash');
     }
 
-    public function testUserLoadFlashesCanBeDisabled()
+    public function testUserLoadFlashesCanBeDisabled(): void
     {
         $this->createFullConfiguration();
 
@@ -368,7 +356,7 @@ class FOSUserExtensionTest extends TestCase
      * @param $dbDriver
      * @param $doctrineService
      */
-    public function testUserManagerSetFactory($dbDriver, $doctrineService)
+    public function testUserManagerSetFactory($dbDriver, $doctrineService): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
@@ -383,19 +371,16 @@ class FOSUserExtensionTest extends TestCase
         if (method_exists($definition, 'getFactory')) {
             $factory = $definition->getFactory();
 
-            $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $factory[0]);
-            $this->assertSame('fos_user.doctrine_registry', (string) $factory[0]);
-            $this->assertSame('getManager', $factory[1]);
+            self::assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $factory[0]);
+            self::assertSame('fos_user.doctrine_registry', (string) $factory[0]);
+            self::assertSame('getManager', $factory[1]);
         } else {
-            $this->assertSame('fos_user.doctrine_registry', $definition->getFactoryService());
-            $this->assertSame('getManager', $definition->getFactoryMethod());
+            self::assertSame('fos_user.doctrine_registry', $definition->getFactoryService());
+            self::assertSame('getManager', $definition->getFactoryMethod());
         }
     }
 
-    /**
-     * @return array
-     */
-    public function userManagerSetFactoryProvider()
+    public function userManagerSetFactoryProvider(): array
     {
         return [
             ['orm', 'doctrine'],
@@ -404,30 +389,25 @@ class FOSUserExtensionTest extends TestCase
         ];
     }
 
-    protected function createEmptyConfiguration()
+    protected function createEmptyConfiguration(): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
         $config = $this->getEmptyConfig();
         $loader->load([$config], $this->configuration);
-        $this->assertTrue($this->configuration instanceof ContainerBuilder);
+        self::assertInstanceOf(ContainerBuilder::class, $this->configuration);
     }
 
-    protected function createFullConfiguration()
+    protected function createFullConfiguration(): void
     {
         $this->configuration = new ContainerBuilder();
         $loader = new FOSUserExtension();
         $config = $this->getFullConfig();
         $loader->load([$config], $this->configuration);
-        $this->assertTrue($this->configuration instanceof ContainerBuilder);
+        self::assertInstanceOf(ContainerBuilder::class, $this->configuration);
     }
 
-    /**
-     * getEmptyConfig.
-     *
-     * @return array
-     */
-    protected function getEmptyConfig()
+    protected function getEmptyConfig(): array
     {
         $yaml = <<<EOF
 db_driver: mongodb
@@ -508,37 +488,26 @@ EOF;
         return $parser->parse($yaml);
     }
 
-    /**
-     * @param string $value
-     * @param string $key
-     */
-    private function assertAlias($value, $key)
+    private function assertAlias(string $value, string $key): void
     {
-        $this->assertSame($value, (string) $this->configuration->getAlias($key), sprintf('%s alias is correct', $key));
+        self::assertSame($value, (string) $this->configuration->getAlias($key), sprintf('%s alias is correct', $key));
     }
 
     /**
-     * @param mixed  $value
-     * @param string $key
+     * @param mixed $value
      */
-    private function assertParameter($value, $key)
+    private function assertParameter($value, string $key): void
     {
-        $this->assertSame($value, $this->configuration->getParameter($key), sprintf('%s parameter is correct', $key));
+        self::assertSame($value, $this->configuration->getParameter($key), sprintf('%s parameter is correct', $key));
     }
 
-    /**
-     * @param string $id
-     */
-    private function assertHasDefinition($id)
+    private function assertHasDefinition(string $id): void
     {
-        $this->assertTrue(($this->configuration->hasDefinition($id) ?: $this->configuration->hasAlias($id)));
+        self::assertTrue(($this->configuration->hasDefinition($id) ?: $this->configuration->hasAlias($id)));
     }
 
-    /**
-     * @param string $id
-     */
-    private function assertNotHasDefinition($id)
+    private function assertNotHasDefinition(string $id): void
     {
-        $this->assertFalse(($this->configuration->hasDefinition($id) ?: $this->configuration->hasAlias($id)));
+        self::assertFalse(($this->configuration->hasDefinition($id) ?: $this->configuration->hasAlias($id)));
     }
 }

--- a/Tests/EventListener/AuthenticationListenerTest.php
+++ b/Tests/EventListener/AuthenticationListenerTest.php
@@ -14,41 +14,39 @@ namespace FOS\UserBundle\Tests\EventListener;
 use FOS\UserBundle\Event\FilterUserResponseEvent;
 use FOS\UserBundle\EventListener\AuthenticationListener;
 use FOS\UserBundle\FOSUserEvents;
+use FOS\UserBundle\Security\LoginManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class AuthenticationListenerTest extends TestCase
 {
-    const FIREWALL_NAME = 'foo';
+    public const FIREWALL_NAME = 'foo';
 
-    /** @var EventDispatcherInterface */
-    private $eventDispatcher;
+    private EventDispatcherInterface $eventDispatcher;
+    private FilterUserResponseEvent $event;
+    private AuthenticationListener $listener;
 
-    /** @var FilterUserResponseEvent */
-    private $event;
-
-    /** @var AuthenticationListener */
-    private $listener;
-
-    protected function setUp()
+    protected function setUp(): void
     {
         $user = $this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock();
 
-        $response = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')->getMock();
-        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
+        $response = $this->getMockBuilder(Response::class)->getMock();
+        $request = $this->getMockBuilder(Request::class)->getMock();
         $this->event = new FilterUserResponseEvent($user, $request, $response);
 
         $this->eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')->getMock();
         $this->eventDispatcher
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('dispatch');
 
-        $loginManager = $this->getMockBuilder('FOS\UserBundle\Security\LoginManagerInterface')->getMock();
+        $loginManager = $this->getMockBuilder(LoginManagerInterface::class)->getMock();
 
         $this->listener = new AuthenticationListener($loginManager, self::FIREWALL_NAME);
     }
 
-    public function testAuthenticate()
+    public function testAuthenticate(): void
     {
         $this->listener->authenticate($this->event, FOSUserEvents::REGISTRATION_COMPLETED, $this->eventDispatcher);
     }

--- a/Tests/EventListener/FlashListenerTest.php
+++ b/Tests/EventListener/FlashListenerTest.php
@@ -14,35 +14,34 @@ namespace FOS\UserBundle\Tests\EventListener;
 use FOS\UserBundle\EventListener\FlashListener;
 use FOS\UserBundle\FOSUserEvents;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Contracts\EventDispatcher\Event;
-
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FlashListenerTest extends TestCase
 {
-    /** @var Event */
-    private $event;
+    private Event $event;
+    private FlashListener $listener;
 
-    /** @var FlashListener */
-    private $listener;
-
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->event = new Event();
 
-        $flashBag = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Flash\FlashBag')->getMock();
+        $flashBag = $this->getMockBuilder(FlashBag::class)->getMock();
 
-        $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')->disableOriginalConstructor()->getMock();
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
         $session
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getFlashBag')
             ->willReturn($flashBag);
 
-        $translator = $this->getMockBuilder('Symfony\Contracts\Translation\TranslatorInterface')->getMock();
+        $translator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
 
         $this->listener = new FlashListener($session, $translator);
     }
 
-    public function testAddSuccessFlash()
+    public function testAddSuccessFlash(): void
     {
         $this->listener->addSuccessFlash($this->event, FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
     }

--- a/Tests/Form/Type/ChangePasswordFormTypeTest.php
+++ b/Tests/Form/Type/ChangePasswordFormTypeTest.php
@@ -16,7 +16,7 @@ use FOS\UserBundle\Tests\TestUser;
 
 class ChangePasswordFormTypeTest extends ValidatorExtensionTypeTestCase
 {
-    public function testSubmit()
+    public function testSubmit(): void
     {
         $user = new TestUser();
         $user->setPassword('foo');
@@ -31,18 +31,15 @@ class ChangePasswordFormTypeTest extends ValidatorExtensionTypeTestCase
         ];
         $form->submit($formData);
 
-        $this->assertTrue($form->isSynchronized());
-        $this->assertSame($user, $form->getData());
-        $this->assertSame('bar', $user->getPlainPassword());
+        self::assertTrue($form->isSynchronized());
+        self::assertSame($user, $form->getData());
+        self::assertSame('bar', $user->getPlainPassword());
     }
 
-    /**
-     * @return array
-     */
-    protected function getTypes()
+    protected function getTypes(): array
     {
         return array_merge(parent::getTypes(), [
-            new ChangePasswordFormType('FOS\UserBundle\Tests\TestUser'),
+            new ChangePasswordFormType(TestUser::class),
         ]);
     }
 }

--- a/Tests/Form/Type/GroupFormTypeTest.php
+++ b/Tests/Form/Type/GroupFormTypeTest.php
@@ -16,7 +16,7 @@ use FOS\UserBundle\Tests\TestGroup;
 
 class GroupFormTypeTest extends TypeTestCase
 {
-    public function testSubmit()
+    public function testSubmit(): void
     {
         $group = new TestGroup('foo');
 
@@ -26,18 +26,15 @@ class GroupFormTypeTest extends TypeTestCase
         ];
         $form->submit($formData);
 
-        $this->assertTrue($form->isSynchronized());
-        $this->assertSame($group, $form->getData());
-        $this->assertSame('bar', $group->getName());
+        self::assertTrue($form->isSynchronized());
+        self::assertSame($group, $form->getData());
+        self::assertSame('bar', $group->getName());
     }
 
-    /**
-     * @return array
-     */
-    protected function getTypes()
+    protected function getTypes(): array
     {
         return array_merge(parent::getTypes(), [
-            new GroupFormType('FOS\UserBundle\Tests\TestGroup'),
+            new GroupFormType(TestGroup::class),
         ]);
     }
 }

--- a/Tests/Form/Type/ProfileFormTypeTest.php
+++ b/Tests/Form/Type/ProfileFormTypeTest.php
@@ -16,7 +16,7 @@ use FOS\UserBundle\Tests\TestUser;
 
 class ProfileFormTypeTest extends ValidatorExtensionTypeTestCase
 {
-    public function testSubmit()
+    public function testSubmit(): void
     {
         $user = new TestUser();
 
@@ -27,19 +27,16 @@ class ProfileFormTypeTest extends ValidatorExtensionTypeTestCase
         ];
         $form->submit($formData);
 
-        $this->assertTrue($form->isSynchronized());
-        $this->assertSame($user, $form->getData());
-        $this->assertSame('bar', $user->getUsername());
-        $this->assertSame('john@doe.com', $user->getEmail());
+        self::assertTrue($form->isSynchronized());
+        self::assertSame($user, $form->getData());
+        self::assertSame('bar', $user->getUsername());
+        self::assertSame('john@doe.com', $user->getEmail());
     }
 
-    /**
-     * @return array
-     */
-    protected function getTypes()
+    protected function getTypes(): array
     {
         return array_merge(parent::getTypes(), [
-            new ProfileFormType('FOS\UserBundle\Tests\TestUser'),
+            new ProfileFormType(TestUser::class),
         ]);
     }
 }

--- a/Tests/Form/Type/RegistrationFormTypeTest.php
+++ b/Tests/Form/Type/RegistrationFormTypeTest.php
@@ -16,7 +16,7 @@ use FOS\UserBundle\Tests\TestUser;
 
 class RegistrationFormTypeTest extends ValidatorExtensionTypeTestCase
 {
-    public function testSubmit()
+    public function testSubmit(): void
     {
         $user = new TestUser();
 
@@ -31,20 +31,17 @@ class RegistrationFormTypeTest extends ValidatorExtensionTypeTestCase
         ];
         $form->submit($formData);
 
-        $this->assertTrue($form->isSynchronized());
-        $this->assertSame($user, $form->getData());
-        $this->assertSame('bar', $user->getUsername());
-        $this->assertSame('john@doe.com', $user->getEmail());
-        $this->assertSame('test', $user->getPlainPassword());
+        self::assertTrue($form->isSynchronized());
+        self::assertSame($user, $form->getData());
+        self::assertSame('bar', $user->getUsername());
+        self::assertSame('john@doe.com', $user->getEmail());
+        self::assertSame('test', $user->getPlainPassword());
     }
 
-    /**
-     * @return array
-     */
-    protected function getTypes()
+    protected function getTypes(): array
     {
         return array_merge(parent::getTypes(), [
-            new RegistrationFormType('FOS\UserBundle\Tests\TestUser'),
+            new RegistrationFormType(TestUser::class),
         ]);
     }
 }

--- a/Tests/Form/Type/ResettingFormTypeTest.php
+++ b/Tests/Form/Type/ResettingFormTypeTest.php
@@ -16,7 +16,7 @@ use FOS\UserBundle\Tests\TestUser;
 
 class ResettingFormTypeTest extends ValidatorExtensionTypeTestCase
 {
-    public function testSubmit()
+    public function testSubmit(): void
     {
         $user = new TestUser();
 
@@ -29,18 +29,15 @@ class ResettingFormTypeTest extends ValidatorExtensionTypeTestCase
         ];
         $form->submit($formData);
 
-        $this->assertTrue($form->isSynchronized());
-        $this->assertSame($user, $form->getData());
-        $this->assertSame('test', $user->getPlainPassword());
+        self::assertTrue($form->isSynchronized());
+        self::assertSame($user, $form->getData());
+        self::assertSame('test', $user->getPlainPassword());
     }
 
-    /**
-     * @return array
-     */
-    protected function getTypes()
+    protected function getTypes(): array
     {
         return array_merge(parent::getTypes(), [
-            new ResettingFormType('FOS\UserBundle\Tests\TestUser'),
+            new ResettingFormType(TestUser::class),
         ]);
     }
 }

--- a/Tests/Form/Type/TypeTestCase.php
+++ b/Tests/Form/Type/TypeTestCase.php
@@ -37,18 +37,12 @@ abstract class TypeTestCase extends BaseTypeTestCase
         $this->builder = new FormBuilder(null, null, $this->dispatcher, $this->factory);
     }
 
-    /**
-     * @return array
-     */
-    protected function getTypeExtensions()
+    protected function getTypeExtensions(): array
     {
         return [];
     }
 
-    /**
-     * @return array
-     */
-    protected function getTypes()
+    protected function getTypes(): array
     {
         return [];
     }

--- a/Tests/Form/Type/ValidatorExtensionTypeTestCase.php
+++ b/Tests/Form/Type/ValidatorExtensionTypeTestCase.php
@@ -13,6 +13,7 @@ namespace FOS\UserBundle\Tests\Form\Type;
 
 use Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Class ValidatorExtensionTypeTestCase
@@ -22,13 +23,10 @@ use Symfony\Component\Validator\ConstraintViolationList;
  */
 class ValidatorExtensionTypeTestCase extends TypeTestCase
 {
-    /**
-     * @return array
-     */
-    protected function getTypeExtensions()
+    protected function getTypeExtensions(): array
     {
-        $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')->getMock();
-        $validator->method('validate')->will($this->returnValue(new ConstraintViolationList()));
+        $validator = $this->getMockBuilder(ValidatorInterface::class)->getMock();
+        $validator->method('validate')->willReturn(new ConstraintViolationList());
 
         return [
             new FormTypeValidatorExtension($validator),

--- a/Tests/Mailer/MailerTest.php
+++ b/Tests/Mailer/MailerTest.php
@@ -12,6 +12,8 @@
 namespace FOS\UserBundle\Tests\Mailer;
 
 use FOS\UserBundle\Mailer\Mailer;
+use FOS\UserBundle\Mailer\TemplateInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Swift_Mailer;
 use Swift_Transport_NullTransport;
@@ -21,20 +23,20 @@ class MailerTest extends TestCase
     /**
      * @dataProvider goodEmailProvider
      */
-    public function testSendConfirmationEmailMessageWithGoodEmails($emailAddress)
+    public function testSendConfirmationEmailMessageWithGoodEmails($emailAddress): void
     {
         $mailer = $this->getMailer();
         $mailer->sendConfirmationEmailMessage($this->getUser($emailAddress));
 
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
     /**
      * @dataProvider badEmailProvider
-     * @expectedException \Swift_RfcComplianceException
      */
-    public function testSendConfirmationEmailMessageWithBadEmails($emailAddress)
+    public function testSendConfirmationEmailMessageWithBadEmails($emailAddress): void
     {
+        $this->expectException(\Swift_RfcComplianceException::class);
         $mailer = $this->getMailer();
         $mailer->sendConfirmationEmailMessage($this->getUser($emailAddress));
     }
@@ -42,25 +44,25 @@ class MailerTest extends TestCase
     /**
      * @dataProvider goodEmailProvider
      */
-    public function testSendResettingEmailMessageWithGoodEmails($emailAddress)
+    public function testSendResettingEmailMessageWithGoodEmails($emailAddress): void
     {
         $mailer = $this->getMailer();
         $mailer->sendResettingEmailMessage($this->getUser($emailAddress));
 
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
     /**
      * @dataProvider badEmailProvider
-     * @expectedException \Swift_RfcComplianceException
      */
-    public function testSendResettingEmailMessageWithBadEmails($emailAddress)
+    public function testSendResettingEmailMessageWithBadEmails($emailAddress): void
     {
+        $this->expectException(\Swift_RfcComplianceException::class);
         $mailer = $this->getMailer();
         $mailer->sendResettingEmailMessage($this->getUser($emailAddress));
     }
 
-    public function goodEmailProvider()
+    public function goodEmailProvider(): array
     {
         return [
             ['foo@example.com'],
@@ -70,7 +72,7 @@ class MailerTest extends TestCase
         ];
     }
 
-    public function badEmailProvider()
+    public function badEmailProvider(): array
     {
         return [
             ['foo'],
@@ -78,7 +80,7 @@ class MailerTest extends TestCase
         ];
     }
 
-    private function getMailer()
+    private function getMailer(): Mailer
     {
         return new Mailer(
             new Swift_Mailer(
@@ -99,9 +101,9 @@ class MailerTest extends TestCase
         );
     }
 
-    private function getTemplating()
+    private function getTemplating(): MockObject
     {
-        $templating = $this->getMockBuilder('FOS\UserBundle\Mailer\TemplateInterface')
+        $templating = $this->getMockBuilder(TemplateInterface::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -109,7 +111,7 @@ class MailerTest extends TestCase
         return $templating;
     }
 
-    private function getUser($emailAddress)
+    private function getUser($emailAddress): MockObject
     {
         $user = $this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock();
         $user->method('getEmail')
@@ -119,7 +121,7 @@ class MailerTest extends TestCase
         return $user;
     }
 
-    private function getEmailAddressValueObject($emailAddressAsString)
+    private function getEmailAddressValueObject($emailAddressAsString): MockObject
     {
         $emailAddress = $this->getMockBuilder('EmailAddress')
            ->setMethods(['__toString'])

--- a/Tests/Mailer/TwigSwiftMailerTest.php
+++ b/Tests/Mailer/TwigSwiftMailerTest.php
@@ -12,9 +12,11 @@
 namespace FOS\UserBundle\Tests\Mailer;
 
 use FOS\UserBundle\Mailer\TwigSwiftMailer;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Swift_Mailer;
 use Swift_Transport_NullTransport;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
@@ -23,20 +25,20 @@ class TwigSwiftMailerTest extends TestCase
     /**
      * @dataProvider goodEmailProvider
      */
-    public function testSendConfirmationEmailMessageWithGoodEmails($emailAddress)
+    public function testSendConfirmationEmailMessageWithGoodEmails($emailAddress): void
     {
         $mailer = $this->getTwigSwiftMailer();
         $mailer->sendConfirmationEmailMessage($this->getUser($emailAddress));
 
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
     /**
      * @dataProvider badEmailProvider
-     * @expectedException \Swift_RfcComplianceException
      */
-    public function testSendConfirmationEmailMessageWithBadEmails($emailAddress)
+    public function testSendConfirmationEmailMessageWithBadEmails($emailAddress): void
     {
+        $this->expectException(\Swift_RfcComplianceException::class);
         $mailer = $this->getTwigSwiftMailer();
         $mailer->sendConfirmationEmailMessage($this->getUser($emailAddress));
     }
@@ -44,25 +46,25 @@ class TwigSwiftMailerTest extends TestCase
     /**
      * @dataProvider goodEmailProvider
      */
-    public function testSendResettingEmailMessageWithGoodEmails($emailAddress)
+    public function testSendResettingEmailMessageWithGoodEmails($emailAddress): void
     {
         $mailer = $this->getTwigSwiftMailer();
         $mailer->sendResettingEmailMessage($this->getUser($emailAddress));
 
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
     /**
      * @dataProvider badEmailProvider
-     * @expectedException \Swift_RfcComplianceException
      */
-    public function testSendResettingEmailMessageWithBadEmails($emailAddress)
+    public function testSendResettingEmailMessageWithBadEmails($emailAddress): void
     {
+        $this->expectException(\Swift_RfcComplianceException::class);
         $mailer = $this->getTwigSwiftMailer();
         $mailer->sendResettingEmailMessage($this->getUser($emailAddress));
     }
 
-    public function goodEmailProvider()
+    public function goodEmailProvider(): array
     {
         return [
             ['foo@example.com'],
@@ -72,7 +74,7 @@ class TwigSwiftMailerTest extends TestCase
         ];
     }
 
-    public function badEmailProvider()
+    public function badEmailProvider(): array
     {
         return [
             ['foo'],
@@ -80,7 +82,7 @@ class TwigSwiftMailerTest extends TestCase
         ];
     }
 
-    private function getTwigSwiftMailer()
+    private function getTwigSwiftMailer(): TwigSwiftMailer
     {
         return new TwigSwiftMailer(
             new Swift_Mailer(
@@ -88,7 +90,7 @@ class TwigSwiftMailerTest extends TestCase
                     $this->getMockBuilder('Swift_Events_EventDispatcher')->getMock()
                 )
             ),
-            $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock(),
+            $this->getMockBuilder(UrlGeneratorInterface::class)->getMock(),
             [
                 'template' => [
                     'confirmation' => 'foo',
@@ -103,7 +105,7 @@ class TwigSwiftMailerTest extends TestCase
         );
     }
 
-    private function getTwigEnvironment()
+    private function getTwigEnvironment(): Environment
     {
         return new Environment(new ArrayLoader(['foo' => <<<'TWIG'
 {% block subject 'foo' %}
@@ -114,7 +116,7 @@ TWIG
         ]));
     }
 
-    private function getUser($emailAddress)
+    private function getUser($emailAddress): MockObject
     {
         $user = $this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock();
         $user->method('getEmail')
@@ -124,7 +126,7 @@ TWIG
         return $user;
     }
 
-    private function getEmailAddressValueObject($emailAddressAsString)
+    private function getEmailAddressValueObject($emailAddressAsString): MockObject
     {
         $emailAddress = $this->getMockBuilder('EmailAddress')
            ->setMethods(['__toString'])

--- a/Tests/Model/UserManagerTest.php
+++ b/Tests/Model/UserManagerTest.php
@@ -9,26 +9,37 @@
  * file that was distributed with this source code.
  */
 
+/** @noinspection StaticInvocationViaThisInspection */
+/** @noinspection StaticInvocationViaThisInspection */
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\UserBundle\Tests\Model;
 
+use FOS\UserBundle\Model\User;
 use FOS\UserBundle\Model\UserManager;
+use FOS\UserBundle\Util\CanonicalFieldsUpdater;
+use FOS\UserBundle\Util\PasswordUpdaterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class UserManagerTest extends TestCase
 {
-    /** @var UserManager|\PHPUnit_Framework_MockObject_MockObject */
-    private $manager;
+    private MockObject $manager;
+    private MockObject $passwordUpdater;
+    private MockObject $fieldsUpdater;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
-    private $passwordUpdater;
-
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
-    private $fieldsUpdater;
-
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->passwordUpdater = $this->getMockBuilder('FOS\UserBundle\Util\PasswordUpdaterInterface')->getMock();
-        $this->fieldsUpdater = $this->getMockBuilder('FOS\UserBundle\Util\CanonicalFieldsUpdater')
+        $this->passwordUpdater = $this->getMockBuilder(PasswordUpdaterInterface::class)->getMock();
+        $this->fieldsUpdater = $this->getMockBuilder(CanonicalFieldsUpdater::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -38,133 +49,133 @@ class UserManagerTest extends TestCase
         ]);
     }
 
-    public function testUpdateCanonicalFields()
+    public function testUpdateCanonicalFields(): void
     {
         $user = $this->getUser();
 
-        $this->fieldsUpdater->expects($this->once())
+        $this->fieldsUpdater->expects(self::once())
             ->method('updateCanonicalFields')
-            ->with($this->identicalTo($user));
+            ->with(self::identicalTo($user));
 
         $this->manager->updateCanonicalFields($user);
     }
 
-    public function testUpdatePassword()
+    public function testUpdatePassword(): void
     {
         $user = $this->getUser();
 
-        $this->passwordUpdater->expects($this->once())
+        $this->passwordUpdater->expects(self::once())
             ->method('hashPassword')
-            ->with($this->identicalTo($user));
+            ->with(self::identicalTo($user));
 
         $this->manager->updatePassword($user);
     }
 
-    public function testFindUserByUsername()
+    public function testFindUserByUsername(): void
     {
-        $this->manager->expects($this->once())
+        $this->manager->expects(self::once())
             ->method('findUserBy')
-            ->with($this->equalTo(['usernameCanonical' => 'jack']));
-        $this->fieldsUpdater->expects($this->once())
+            ->with(self::equalTo(['usernameCanonical' => 'jack']));
+        $this->fieldsUpdater->expects(self::once())
             ->method('canonicalizeUsername')
             ->with('jack')
-            ->will($this->returnValue('jack'));
+            ->willReturn('jack');
 
         $this->manager->findUserByUsername('jack');
     }
 
-    public function testFindUserByUsernameLowercasesTheUsername()
+    public function testFindUserByUsernameLowercasesTheUsername(): void
     {
-        $this->manager->expects($this->once())
+        $this->manager->expects(self::once())
             ->method('findUserBy')
-            ->with($this->equalTo(['usernameCanonical' => 'jack']));
-        $this->fieldsUpdater->expects($this->once())
+            ->with(self::equalTo(['usernameCanonical' => 'jack']));
+        $this->fieldsUpdater->expects(self::once())
             ->method('canonicalizeUsername')
             ->with('JaCk')
-            ->will($this->returnValue('jack'));
+            ->willReturn('jack');
 
         $this->manager->findUserByUsername('JaCk');
     }
 
-    public function testFindUserByEmail()
+    public function testFindUserByEmail(): void
     {
-        $this->manager->expects($this->once())
+        $this->manager->expects(self::once())
             ->method('findUserBy')
-            ->with($this->equalTo(['emailCanonical' => 'jack@email.org']));
-        $this->fieldsUpdater->expects($this->once())
+            ->with(self::equalTo(['emailCanonical' => 'jack@email.org']));
+        $this->fieldsUpdater->expects(self::once())
             ->method('canonicalizeEmail')
             ->with('jack@email.org')
-            ->will($this->returnValue('jack@email.org'));
+            ->willReturn('jack@email.org');
 
         $this->manager->findUserByEmail('jack@email.org');
     }
 
-    public function testFindUserByEmailLowercasesTheEmail()
+    public function testFindUserByEmailLowercasesTheEmail(): void
     {
-        $this->manager->expects($this->once())
+        $this->manager->expects(self::once())
             ->method('findUserBy')
-            ->with($this->equalTo(['emailCanonical' => 'jack@email.org']));
-        $this->fieldsUpdater->expects($this->once())
+            ->with(self::equalTo(['emailCanonical' => 'jack@email.org']));
+        $this->fieldsUpdater->expects(self::once())
             ->method('canonicalizeEmail')
             ->with('JaCk@EmAiL.oRg')
-            ->will($this->returnValue('jack@email.org'));
+            ->willReturn('jack@email.org');
 
         $this->manager->findUserByEmail('JaCk@EmAiL.oRg');
     }
 
-    public function testFindUserByUsernameOrEmailWithUsername()
+    public function testFindUserByUsernameOrEmailWithUsername(): void
     {
-        $this->manager->expects($this->once())
+        $this->manager->expects(self::once())
             ->method('findUserBy')
-            ->with($this->equalTo(['usernameCanonical' => 'jack']));
-        $this->fieldsUpdater->expects($this->once())
+            ->with(self::equalTo(['usernameCanonical' => 'jack']));
+        $this->fieldsUpdater->expects(self::once())
             ->method('canonicalizeUsername')
             ->with('JaCk')
-            ->will($this->returnValue('jack'));
+            ->willReturn('jack');
 
         $this->manager->findUserByUsernameOrEmail('JaCk');
     }
 
-    public function testFindUserByUsernameOrEmailWithEmail()
+    public function testFindUserByUsernameOrEmailWithEmail(): void
     {
-        $this->manager->expects($this->once())
+        $this->manager->expects(self::once())
             ->method('findUserBy')
-            ->with($this->equalTo(['emailCanonical' => 'jack@email.org']))
+            ->with(self::equalTo(['emailCanonical' => 'jack@email.org']))
             ->willReturn($this->getUser());
-        $this->fieldsUpdater->expects($this->once())
+        $this->fieldsUpdater->expects(self::once())
             ->method('canonicalizeEmail')
             ->with('JaCk@EmAiL.oRg')
-            ->will($this->returnValue('jack@email.org'));
+            ->willReturn('jack@email.org');
 
         $this->manager->findUserByUsernameOrEmail('JaCk@EmAiL.oRg');
     }
 
-    public function testFindUserByUsernameOrEmailWithUsernameThatLooksLikeEmail()
+    public function testFindUserByUsernameOrEmailWithUsernameThatLooksLikeEmail(): void
     {
         $usernameThatLooksLikeEmail = 'bob@example.com';
         $user = $this->getUser();
 
-        $this->manager->expects($this->at(0))
+        $this->manager->expects(self::at(0))
             ->method('findUserBy')
-            ->with($this->equalTo(['emailCanonical' => $usernameThatLooksLikeEmail]))
-            ->will($this->returnValue(null));
-        $this->fieldsUpdater->expects($this->once())
+            ->with(self::equalTo(['emailCanonical' => $usernameThatLooksLikeEmail]))
+            ->willReturn(null);
+        $this->fieldsUpdater->expects(self::once())
             ->method('canonicalizeEmail')
             ->with($usernameThatLooksLikeEmail)
             ->willReturn($usernameThatLooksLikeEmail);
 
-        $this->manager->expects($this->at(1))
+        $this->manager->expects(self::at(1))
             ->method('findUserBy')
-            ->with($this->equalTo(['usernameCanonical' => $usernameThatLooksLikeEmail]))
-            ->will($this->returnValue($user));
-        $this->fieldsUpdater->expects($this->once())
+            ->with(self::equalTo(['usernameCanonical' => $usernameThatLooksLikeEmail]))
+            ->willReturn($user);
+        $this->fieldsUpdater->expects(self::once())
             ->method('canonicalizeUsername')
             ->with($usernameThatLooksLikeEmail)
             ->willReturn($usernameThatLooksLikeEmail);
 
         $actualUser = $this->manager->findUserByUsernameOrEmail($usernameThatLooksLikeEmail);
 
-        $this->assertSame($user, $actualUser);
+        self::assertSame($user, $actualUser);
     }
 
     /**
@@ -172,7 +183,7 @@ class UserManagerTest extends TestCase
      */
     private function getUser()
     {
-        return $this->getMockBuilder('FOS\UserBundle\Model\User')
+        return $this->getMockBuilder(User::class)
             ->getMockForAbstractClass();
     }
 
@@ -181,7 +192,7 @@ class UserManagerTest extends TestCase
      */
     private function getUserManager(array $args)
     {
-        return $this->getMockBuilder('FOS\UserBundle\Model\UserManager')
+        return $this->getMockBuilder(UserManager::class)
             ->setConstructorArgs($args)
             ->getMockForAbstractClass();
     }

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -16,37 +16,37 @@ use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase
 {
-    public function testUsername()
+    public function testUsername(): void
     {
         $user = $this->getUser();
-        $this->assertNull($user->getUsername());
+        self::assertNull($user->getUsername());
 
         $user->setUsername('tony');
-        $this->assertSame('tony', $user->getUsername());
+        self::assertSame('tony', $user->getUsername());
     }
 
-    public function testEmail()
+    public function testEmail(): void
     {
         $user = $this->getUser();
-        $this->assertNull($user->getEmail());
+        self::assertNull($user->getEmail());
 
         $user->setEmail('tony@mail.org');
-        $this->assertSame('tony@mail.org', $user->getEmail());
+        self::assertSame('tony@mail.org', $user->getEmail());
     }
 
-    public function testIsPasswordRequestNonExpired()
+    public function testIsPasswordRequestNonExpired(): void
     {
         $user = $this->getUser();
         $passwordRequestedAt = new \DateTime('-10 seconds');
 
         $user->setPasswordRequestedAt($passwordRequestedAt);
 
-        $this->assertSame($passwordRequestedAt, $user->getPasswordRequestedAt());
-        $this->assertTrue($user->isPasswordRequestNonExpired(15));
-        $this->assertFalse($user->isPasswordRequestNonExpired(5));
+        self::assertSame($passwordRequestedAt, $user->getPasswordRequestedAt());
+        self::assertTrue($user->isPasswordRequestNonExpired(15));
+        self::assertFalse($user->isPasswordRequestNonExpired(5));
     }
 
-    public function testIsPasswordRequestAtCleared()
+    public function testIsPasswordRequestAtCleared(): void
     {
         $user = $this->getUser();
         $passwordRequestedAt = new \DateTime('-10 seconds');
@@ -54,55 +54,52 @@ class UserTest extends TestCase
         $user->setPasswordRequestedAt($passwordRequestedAt);
         $user->setPasswordRequestedAt(null);
 
-        $this->assertFalse($user->isPasswordRequestNonExpired(15));
-        $this->assertFalse($user->isPasswordRequestNonExpired(5));
+        self::assertFalse($user->isPasswordRequestNonExpired(15));
+        self::assertFalse($user->isPasswordRequestNonExpired(5));
     }
 
-    public function testTrueHasRole()
+    public function testTrueHasRole(): void
     {
         $user = $this->getUser();
         $defaultrole = User::ROLE_DEFAULT;
         $newrole = 'ROLE_X';
-        $this->assertTrue($user->hasRole($defaultrole));
+        self::assertTrue($user->hasRole($defaultrole));
         $user->addRole($defaultrole);
-        $this->assertTrue($user->hasRole($defaultrole));
+        self::assertTrue($user->hasRole($defaultrole));
         $user->addRole($newrole);
-        $this->assertTrue($user->hasRole($newrole));
+        self::assertTrue($user->hasRole($newrole));
     }
 
-    public function testFalseHasRole()
+    public function testFalseHasRole(): void
     {
         $user = $this->getUser();
         $newrole = 'ROLE_X';
-        $this->assertFalse($user->hasRole($newrole));
+        self::assertFalse($user->hasRole($newrole));
         $user->addRole($newrole);
-        $this->assertTrue($user->hasRole($newrole));
+        self::assertTrue($user->hasRole($newrole));
     }
 
-    public function testIsEqualTo()
+    public function testIsEqualTo(): void
     {
         $user = $this->getUser();
-        $this->assertTrue($user->isEqualTo($user));
-        $this->assertFalse($user->isEqualTo($this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock()));
+        self::assertTrue($user->isEqualTo($user));
+        self::assertFalse($user->isEqualTo($this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock()));
 
         $user2 = $this->getUser();
         $user2->setPassword('secret');
-        $this->assertFalse($user->isEqualTo($user2));
+        self::assertFalse($user->isEqualTo($user2));
 
         $user3 = $this->getUser();
         $user3->setSalt('pepper');
-        $this->assertFalse($user->isEqualTo($user3));
+        self::assertFalse($user->isEqualTo($user3));
 
         $user4 = $this->getUser();
         $user4->setUsername('f00b4r');
-        $this->assertFalse($user->isEqualTo($user4));
+        self::assertFalse($user->isEqualTo($user4));
     }
 
-    /**
-     * @return User
-     */
-    protected function getUser()
+    protected function getUser(): User
     {
-        return $this->getMockForAbstractClass('FOS\UserBundle\Model\User');
+        return $this->getMockForAbstractClass(User::class);
     }
 }

--- a/Tests/Routing/RoutingTest.php
+++ b/Tests/Routing/RoutingTest.php
@@ -20,11 +20,8 @@ class RoutingTest extends TestCase
 {
     /**
      * @dataProvider loadRoutingProvider
-     *
-     * @param string $routeName
-     * @param string $path
      */
-    public function testLoadRouting($routeName, $path, array $methods)
+    public function testLoadRouting(string $routeName, string $path, array $methods): void
     {
         $locator = new FileLocator();
         $loader = new XmlFileLoader($locator);
@@ -46,15 +43,12 @@ class RoutingTest extends TestCase
         $collection->addCollection($loader->load(__DIR__.'/../../Resources/config/routing/security.xml'));
 
         $route = $collection->get($routeName);
-        $this->assertNotNull($route, sprintf('The route "%s" should exists', $routeName));
-        $this->assertSame($path, $route->getPath());
-        $this->assertSame($methods, $route->getMethods());
+        self::assertNotNull($route, sprintf('The route "%s" should exists', $routeName));
+        self::assertSame($path, $route->getPath());
+        self::assertSame($methods, $route->getMethods());
     }
 
-    /**
-     * @return array
-     */
-    public function loadRoutingProvider()
+    public function loadRoutingProvider(): array
     {
         return [
             ['fos_user_change_password', '/change-password', ['GET', 'POST']],

--- a/Tests/Security/EmailProviderTest.php
+++ b/Tests/Security/EmailProviderTest.php
@@ -11,115 +11,107 @@
 
 namespace FOS\UserBundle\Tests\Security;
 
+use FOS\UserBundle\Model\User;
+use FOS\UserBundle\Model\UserManagerInterface;
 use FOS\UserBundle\Security\EmailProvider;
+use FOS\UserBundle\Security\UserProvider;
+use FOS\UserBundle\Tests\TestUser;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception as SecurityException;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class EmailProviderTest extends TestCase
 {
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    private $userManager;
+    private MockObject $userManager;
+    private UserProvider $userProvider;
 
-    /**
-     * @var UserProvider
-     */
-    private $userProvider;
-
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->userManager = $this->getMockBuilder('FOS\UserBundle\Model\UserManagerInterface')->getMock();
+        $this->userManager = $this->getMockBuilder(UserManagerInterface::class)->getMock();
         $this->userProvider = new EmailProvider($this->userManager);
     }
 
-    public function testLoadUserByUsername()
+    public function testLoadUserByUsername(): void
     {
         $user = $this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock();
-        $this->userManager->expects($this->once())
+        $this->userManager->expects(self::once())
             ->method('findUserByEmail')
             ->with('foobar')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
-        $this->assertSame($user, $this->userProvider->loadUserByUsername('foobar'));
+        self::assertSame($user, $this->userProvider->loadUserByUsername('foobar'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
-    public function testLoadUserByInvalidUsername()
+    public function testLoadUserByInvalidUsername(): void
     {
-        $this->userManager->expects($this->once())
+        $this->expectException(SecurityException\UsernameNotFoundException::class);
+        $this->userManager->expects(self::once())
             ->method('findUserByEmail')
             ->with('foobar')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->userProvider->loadUserByUsername('foobar');
     }
 
-    public function testRefreshUserBy()
+    public function testRefreshUserBy(): void
     {
-        $user = $this->getMockBuilder('FOS\UserBundle\Model\User')
+        $user = $this->getMockBuilder(User::class)
                     ->setMethods(['getId'])
                     ->getMock();
 
-        $user->expects($this->once())
+        $user->expects(self::once())
             ->method('getId')
-            ->will($this->returnValue('123'));
+            ->willReturn('123');
 
         $refreshedUser = $this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock();
-        $this->userManager->expects($this->once())
+        $this->userManager->expects(self::once())
             ->method('findUserBy')
             ->with(['id' => '123'])
-            ->will($this->returnValue($refreshedUser));
+            ->willReturn($refreshedUser);
 
-        $this->userManager->expects($this->atLeastOnce())
+        $this->userManager->expects(self::atLeastOnce())
             ->method('getClass')
-            ->will($this->returnValue(get_class($user)));
+            ->willReturn(get_class($user));
 
-        $this->assertSame($refreshedUser, $this->userProvider->refreshUser($user));
+        self::assertSame($refreshedUser, $this->userProvider->refreshUser($user));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
-    public function testRefreshDeleted()
+    public function testRefreshDeleted(): void
     {
-        $user = $this->getMockForAbstractClass('FOS\UserBundle\Model\User');
-        $this->userManager->expects($this->once())
+        $this->expectException(SecurityException\UsernameNotFoundException::class);
+        $user = $this->getMockForAbstractClass(User::class);
+        $this->userManager->expects(self::once())
             ->method('findUserBy')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $this->userManager->expects($this->atLeastOnce())
+        $this->userManager->expects(self::atLeastOnce())
             ->method('getClass')
-            ->will($this->returnValue(get_class($user)));
+            ->willReturn(get_class($user));
 
         $this->userProvider->refreshUser($user);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UnsupportedUserException
-     */
-    public function testRefreshInvalidUser()
+    public function testRefreshInvalidUser(): void
     {
-        $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
-        $this->userManager->expects($this->any())
+        $this->expectException(SecurityException\UnsupportedUserException::class);
+        $user = $this->getMockBuilder(UserInterface::class)->getMock();
+        $this->userManager
             ->method('getClass')
-            ->will($this->returnValue(get_class($user)));
+            ->willReturn(get_class($user));
 
         $this->userProvider->refreshUser($user);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UnsupportedUserException
-     */
-    public function testRefreshInvalidUserClass()
+    public function testRefreshInvalidUserClass(): void
     {
-        $user = $this->getMockBuilder('FOS\UserBundle\Model\User')->getMock();
-        $providedUser = $this->getMockBuilder('FOS\UserBundle\Tests\TestUser')->getMock();
+        $this->expectException(SecurityException\UnsupportedUserException::class);
+        $user = $this->getMockBuilder(User::class)->getMock();
+        $providedUser = $this->getMockBuilder(TestUser::class)->getMock();
 
-        $this->userManager->expects($this->atLeastOnce())
+        $this->userManager->expects(self::atLeastOnce())
             ->method('getClass')
-            ->will($this->returnValue(get_class($user)));
+            ->willReturn(get_class($user));
 
         $this->userProvider->refreshUser($providedUser);
     }

--- a/Tests/Security/LoginManagerTest.php
+++ b/Tests/Security/LoginManagerTest.php
@@ -13,65 +13,67 @@ namespace FOS\UserBundle\Tests\Security;
 
 use FOS\UserBundle\Security\LoginManager;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 
 class LoginManagerTest extends TestCase
 {
-    public function testLogInUserWithRequestStack()
+    public function testLogInUserWithRequestStack(): void
     {
-        $loginManager = $this->createLoginManager('main');
+        $loginManager = $this->createLoginManager();
         $loginManager->logInUser('main', $this->mockUser());
     }
 
-    public function testLogInUserWithRememberMeAndRequestStack()
+    public function testLogInUserWithRememberMeAndRequestStack(): void
     {
-        $response = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')->getMock();
+        $response = $this->getMockBuilder(Response::class)->getMock();
 
-        $loginManager = $this->createLoginManager('main', $response);
+        $loginManager = $this->createLoginManager($response);
         $loginManager->logInUser('main', $this->mockUser(), $response);
     }
 
-    /**
-     * @param string $firewallName
-     *
-     * @return LoginManager
-     */
-    private function createLoginManager($firewallName, Response $response = null)
+    private function createLoginManager(Response $response = null): LoginManager
     {
-        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('setToken')
-            ->with($this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+            ->with(self::isInstanceOf(TokenInterface::class));
 
-        $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
+        $userChecker = $this->getMockBuilder(UserCheckerInterface::class)->getMock();
         $userChecker
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('checkPreAuth')
-            ->with($this->isInstanceOf('FOS\UserBundle\Model\UserInterface'));
+            ->with(self::isInstanceOf('FOS\UserBundle\Model\UserInterface'));
 
-        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
+        $request = $this->getMockBuilder(Request::class)->getMock();
 
-        $sessionStrategy = $this->getMockBuilder('Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface')->getMock();
+        $sessionStrategy = $this->getMockBuilder(SessionAuthenticationStrategyInterface::class)->getMock();
         $sessionStrategy
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('onAuthentication')
-            ->with($request, $this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+            ->with($request, self::isInstanceOf(TokenInterface::class));
 
-        $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
+        $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $requestStack
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getCurrentRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
 
         $rememberMe = null;
         if (null !== $response) {
-            $rememberMe = $this->getMockBuilder('Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface')->getMock();
+            $rememberMe = $this->getMockBuilder(RememberMeServicesInterface::class)->getMock();
             $rememberMe
-                ->expects($this->once())
+                ->expects(self::once())
                 ->method('loginSuccess')
-                ->with($request, $response, $this->isInstanceOf('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+                ->with($request, $response, self::isInstanceOf(TokenInterface::class));
         }
 
         return new LoginManager($tokenStorage, $userChecker, $sessionStrategy, $requestStack, $rememberMe);
@@ -84,9 +86,9 @@ class LoginManagerTest extends TestCase
     {
         $user = $this->getMockBuilder('FOS\UserBundle\Model\UserInterface')->getMock();
         $user
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRoles')
-            ->will($this->returnValue(['ROLE_USER']));
+            ->willReturn(['ROLE_USER']);
 
         return $user;
     }

--- a/Tests/Security/UserCheckerTest.php
+++ b/Tests/Security/UserCheckerTest.php
@@ -12,79 +12,73 @@
 namespace FOS\UserBundle\Tests\Security;
 
 use FOS\UserBundle\Security\UserChecker;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception as SecurityException;
 
 class UserCheckerTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\LockedException
-     * @expectedExceptionMessage User account is locked.
-     */
-    public function testCheckPreAuthFailsLockedOut()
+    public function testCheckPreAuthFailsLockedOut(): void
     {
+        $this->expectExceptionMessage('User account is locked.');
+        $this->expectException(SecurityException\LockedException::class);
         $userMock = $this->getUser(false, false, false, false);
         $checker = new UserChecker();
         $checker->checkPreAuth($userMock);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\DisabledException
-     * @expectedExceptionMessage User account is disabled.
-     */
-    public function testCheckPreAuthFailsIsEnabled()
+    public function testCheckPreAuthFailsIsEnabled(): void
     {
+        $this->expectExceptionMessage('User account is disabled.');
+        $this->expectException(SecurityException\DisabledException::class);
         $userMock = $this->getUser(true, false, false, false);
         $checker = new UserChecker();
         $checker->checkPreAuth($userMock);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccountExpiredException
-     * @expectedExceptionMessage User account has expired.
-     */
-    public function testCheckPreAuthFailsIsAccountNonExpired()
+    public function testCheckPreAuthFailsIsAccountNonExpired(): void
     {
+        $this->expectException(SecurityException\AccountExpiredException::class);
+        $this->expectExceptionMessage('User account has expired.');
         $userMock = $this->getUser(true, true, false, false);
         $checker = new UserChecker();
         $checker->checkPreAuth($userMock);
     }
 
-    public function testCheckPreAuthSuccess()
+    public function testCheckPreAuthSuccess(): void
     {
         $userMock = $this->getUser(true, true, true, false);
         $checker = new UserChecker();
 
         try {
-            $this->assertNull($checker->checkPreAuth($userMock));
+            self::assertNull($checker->checkPreAuth($userMock));
         } catch (\Exception $ex) {
-            $this->fail();
+            self::fail();
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\CredentialsExpiredException
-     * @expectedExceptionMessage User credentials have expired.
-     */
-    public function testCheckPostAuthFailsIsCredentialsNonExpired()
+    public function testCheckPostAuthFailsIsCredentialsNonExpired(): void
     {
+        $this->expectException(SecurityException\CredentialsExpiredException::class);
+        $this->expectExceptionMessage('User credentials have expired.');
         $userMock = $this->getUser(true, true, true, false);
         $checker = new UserChecker();
         $checker->checkPostAuth($userMock);
     }
 
-    public function testCheckPostAuthSuccess()
+    public function testCheckPostAuthSuccess(): void
     {
         $userMock = $this->getUser(true, true, true, true);
         $checker = new UserChecker();
 
         try {
-            $this->assertNull($checker->checkPostAuth($userMock));
+            self::assertNull($checker->checkPostAuth($userMock));
         } catch (\Exception $ex) {
-            $this->fail();
+            self::fail();
         }
     }
 
-    private function getUser($isAccountNonLocked, $isEnabled, $isAccountNonExpired, $isCredentialsNonExpired)
+    private function getUser($isAccountNonLocked, $isEnabled, $isAccountNonExpired, $isCredentialsNonExpired): MockObject
     {
         $userMock = $this->getMockBuilder('FOS\UserBundle\Model\User')->getMock();
         $userMock

--- a/Tests/Util/CanonicalFieldsUpdaterTest.php
+++ b/Tests/Util/CanonicalFieldsUpdaterTest.php
@@ -13,18 +13,17 @@ namespace FOS\UserBundle\Tests\Util;
 
 use FOS\UserBundle\Tests\TestUser;
 use FOS\UserBundle\Util\CanonicalFieldsUpdater;
+use FOS\UserBundle\Util\CanonicalizerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class CanonicalFieldsUpdaterTest extends TestCase
 {
-    /**
-     * @var CanonicalFieldsUpdater
-     */
-    private $updater;
-    private $usernameCanonicalizer;
-    private $emailCanonicalizer;
+    private CanonicalFieldsUpdater $updater;
+    private MockObject $usernameCanonicalizer;
+    private MockObject $emailCanonicalizer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->usernameCanonicalizer = $this->getMockCanonicalizer();
         $this->emailCanonicalizer = $this->getMockCanonicalizer();
@@ -32,29 +31,29 @@ class CanonicalFieldsUpdaterTest extends TestCase
         $this->updater = new CanonicalFieldsUpdater($this->usernameCanonicalizer, $this->emailCanonicalizer);
     }
 
-    public function testUpdateCanonicalFields()
+    public function testUpdateCanonicalFields(): void
     {
         $user = new TestUser();
         $user->setUsername('Username');
         $user->setEmail('User@Example.com');
 
-        $this->usernameCanonicalizer->expects($this->once())
+        $this->usernameCanonicalizer->expects(self::once())
             ->method('canonicalize')
             ->with('Username')
-            ->will($this->returnCallback('strtolower'));
+            ->willReturnCallback('strtolower');
 
-        $this->emailCanonicalizer->expects($this->once())
+        $this->emailCanonicalizer->expects(self::once())
             ->method('canonicalize')
             ->with('User@Example.com')
-            ->will($this->returnCallback('strtolower'));
+            ->willReturnCallback('strtolower');
 
         $this->updater->updateCanonicalFields($user);
-        $this->assertSame('username', $user->getUsernameCanonical());
-        $this->assertSame('user@example.com', $user->getEmailCanonical());
+        self::assertSame('username', $user->getUsernameCanonical());
+        self::assertSame('user@example.com', $user->getEmailCanonical());
     }
 
-    private function getMockCanonicalizer()
+    private function getMockCanonicalizer(): MockObject
     {
-        return $this->getMockBuilder('FOS\UserBundle\Util\CanonicalizerInterface')->getMock();
+        return $this->getMockBuilder(CanonicalizerInterface::class)->getMock();
     }
 }

--- a/Tests/Util/CanonicalizerTest.php
+++ b/Tests/Util/CanonicalizerTest.php
@@ -22,16 +22,13 @@ class CanonicalizerTest extends TestCase
      * @param $source
      * @param $expectedResult
      */
-    public function testCanonicalize($source, $expectedResult)
+    public function testCanonicalize($source, $expectedResult): void
     {
         $canonicalizer = new Canonicalizer();
-        $this->assertSame($expectedResult, $canonicalizer->canonicalize($source));
+        self::assertSame($expectedResult, $canonicalizer->canonicalize($source));
     }
 
-    /**
-     * @return array
-     */
-    public function canonicalizeProvider()
+    public function canonicalizeProvider(): array
     {
         return [
             [null, null],

--- a/Tests/Util/PasswordUpdaterTest.php
+++ b/Tests/Util/PasswordUpdaterTest.php
@@ -13,46 +13,45 @@ namespace FOS\UserBundle\Tests\Util;
 
 use FOS\UserBundle\Tests\TestUser;
 use FOS\UserBundle\Util\PasswordUpdater;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 
 class PasswordUpdaterTest extends TestCase
 {
-    /**
-     * @var PasswordUpdater
-     */
-    private $updater;
-    private $encoderFactory;
+    private PasswordUpdater $updater;
+    private MockObject $encoderFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->encoderFactory = $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface')->getMock();
+        $this->encoderFactory = $this->getMockBuilder(EncoderFactoryInterface::class)->getMock();
 
         $this->updater = new PasswordUpdater($this->encoderFactory);
     }
 
-    public function testUpdatePassword()
+    public function testUpdatePassword(): void
     {
         $encoder = $this->getMockPasswordEncoder();
         $user = new TestUser();
         $user->setPlainPassword('password');
 
-        $this->encoderFactory->expects($this->once())
+        $this->encoderFactory->expects(self::once())
             ->method('getEncoder')
             ->with($user)
-            ->will($this->returnValue($encoder));
+            ->willReturn($encoder);
 
-        $encoder->expects($this->once())
+        $encoder->expects(self::once())
             ->method('encodePassword')
-            ->with('password', $this->logicalOr($this->isType('string'),$this->isNull()))
-            ->will($this->returnValue('encodedPassword'));
+            ->with('password', self::logicalOr(self::isType('string'), self::isNull()))
+            ->willReturn('encodedPassword');
 
         $this->updater->hashPassword($user);
-        $this->assertSame('encodedPassword', $user->getPassword(), '->updatePassword() sets encoded password');
-        $this->assertNull($user->getPlainPassword(), '->updatePassword() erases credentials');
+        self::assertSame('encodedPassword', $user->getPassword(), '->updatePassword() sets encoded password');
+        self::assertNull($user->getPlainPassword(), '->updatePassword() erases credentials');
     }
 
-     public function testDoesNotUpdateWithoutPlainPassword()
+    public function testDoesNotUpdateWithoutPlainPassword(): void
     {
         $user = new TestUser();
         $user->setPassword('hash');
@@ -60,11 +59,11 @@ class PasswordUpdaterTest extends TestCase
         $user->setPlainPassword('');
 
         $this->updater->hashPassword($user);
-        $this->assertSame('hash', $user->getPassword());
+        self::assertSame('hash', $user->getPassword());
     }
 
-    private function getMockPasswordEncoder()
+    private function getMockPasswordEncoder(): MockObject
     {
-        return $this->getMockBuilder('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface')->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(PasswordEncoderInterface::class)->disableOriginalConstructor()->getMock();
     }
 }

--- a/Util/UserManipulator.php
+++ b/Util/UserManipulator.php
@@ -76,7 +76,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch($event,FOSUserEvents::USER_CREATED);
+        $this->dispatcher->dispatch($event, FOSUserEvents::USER_CREATED);
 
         return $user;
     }
@@ -93,7 +93,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch($event,FOSUserEvents::USER_ACTIVATED);
+        $this->dispatcher->dispatch($event, FOSUserEvents::USER_ACTIVATED);
     }
 
     /**
@@ -108,7 +108,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch($event,FOSUserEvents::USER_DEACTIVATED);
+        $this->dispatcher->dispatch($event, FOSUserEvents::USER_DEACTIVATED);
     }
 
     /**
@@ -124,7 +124,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch($event,FOSUserEvents::USER_PASSWORD_CHANGED);
+        $this->dispatcher->dispatch($event, FOSUserEvents::USER_PASSWORD_CHANGED);
     }
 
     /**
@@ -139,7 +139,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch($event,FOSUserEvents::USER_PROMOTED);
+        $this->dispatcher->dispatch($event, FOSUserEvents::USER_PROMOTED);
     }
 
     /**
@@ -154,7 +154,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch($event,FOSUserEvents::USER_DEMOTED);
+        $this->dispatcher->dispatch($event, FOSUserEvents::USER_DEMOTED);
     }
 
     /**
@@ -218,7 +218,7 @@ class UserManipulator
     }
 
     /**
-     * @return  null|Request
+     * @return Request|null
      */
     private function getRequest()
     {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "evrinoma/user-bundle",
+    "name": "grizzlylab/user-bundle",
     "type": "symfony-bundle",
     "description": "Symfony FOSUserBundle",
     "keywords": [
@@ -22,28 +22,32 @@
         {
             "name": "Nikolay Nikolaev",
             "email": "evrinoma@gmail.com"
+        },
+        {
+            "name": "Jean-Louis Pirson",
+            "email": "jl.pirson@grizzlylab.be"
         }
     ],
     "require": {
-        "php": "^5.5.9 || ^7.1",
-        "paragonie/random_compat": "^1 || ^2 || ^9",
-        "symfony/form": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/templating": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/translation": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/twig-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/validator": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "twig/twig": "^1.28 || ^2.0 || ^3.0"
+        "php": "^7.4",
+        "paragonie/random_compat": "^9",
+        "symfony/form": "~5.1",
+        "symfony/framework-bundle": "~5.1",
+        "symfony/security-bundle": "~5.1",
+        "symfony/templating": "~5.1",
+        "symfony/translation": "~5.1",
+        "symfony/twig-bundle": "~5.1",
+        "symfony/validator": "~5.1",
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.1",
-        "friendsofphp/php-cs-fixer": "^2.2",
-        "phpunit/phpunit": "^4.8.35 || ^5.7.11 || ^6.5",
-        "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
-        "symfony/console": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/yaml": "^2.8 || ^3.0 || ^4.0 || ^5.0"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "phpunit/phpunit": "^9.4",
+        "swiftmailer/swiftmailer": "^6.0",
+        "symfony/console": "~5.1",
+        "symfony/phpunit-bridge": "~5.1",
+        "symfony/yaml": "~5.1"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Hi, I continued your work, my goal being to use this on a project (which started with Symfony 2 and continnued on 3, 4 and now 5.2).

My main goal was to use Symfony 5.2+, then I applied some code styles changes (php-cs-fixer and some manually). 
The blocking thing was the use the ObjectManager and not the EntityManagerInterface.

I dropped support for previous version of Symfony (easier to maintain), a "version" tag should be created to reflect that.

Here are the tests results : 

![tests-results-1](https://user-images.githubusercontent.com/2612537/100646396-472c3300-333e-11eb-9599-e076b4e1d3e3.png)

![tests-results-0](https://user-images.githubusercontent.com/2612537/100646399-47c4c980-333e-11eb-8627-1c0bd560c22b.png)


Hope this helps.